### PR TITLE
Increase download limit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ There are two different pages for `Category` and `Product` translations. Both au
 From this binding list, the first one is always the `X-Vtex-Tenant` or the default language, for this option the details cannot be translated, to modify these values, the changes should be made inside your store's catalog.  
 For all the others, it's possible to edit the content by category and by product. 
 
-It's also possible to export all current translations for `Categories` and `Products`. Inside a binding different than the `X-Vtex-Tenant`, a button called `export` allows user to download the translations for that binding. Curently, it's only possible to export 1.600 products for a given category every 3 minutes.
+It's also possible to export all current translations for `Categories` and `Products`. Inside a binding different than the `X-Vtex-Tenant`, a button called `export` allows user to download the translations for that binding.
 
 ---
 ## Usage

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,5 +1,8 @@
 type Query {
   categoryTranslations(locale: String!, active: Boolean): [Category]
   getCategoriesName: [CategoryName]
-  productTranslations(locale: String!, categoryId: String!): Boolean
+  productTranslations(
+    locale: String!
+    categoryId: String!
+  ): ProductTranslationRequest
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -5,7 +5,7 @@ type Query {
     locale: String!
     categoryId: String!
   ): ProductTranslationRequest
-  translationRequests: [String]
-  translationRequestInfo(requestId: String!): ProductTranslationRequest
+  productTranslationRequests: [String]
+  productTranslationRequestInfo(requestId: String!): ProductTranslationRequest
   downloadProductTranslation(requestId: String!): [Product]
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,5 +1,5 @@
 type Query {
   categoryTranslations(locale: String!, active: Boolean): [Category]
   getCategoriesName: [CategoryName]
-  productTranslations(locale: String!, categoryId: String!): [Product]
+  productTranslations(locale: String!, categoryId: String!): Boolean
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -5,4 +5,7 @@ type Query {
     locale: String!
     categoryId: String!
   ): ProductTranslationRequest
+  translationRequests: [String]
+  translationRequestInfo(requestId: String!): ProductTranslationRequest
+  downloadProductTranslation(requestId: String!): [Product]
 }

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -16,4 +16,5 @@ type ProductTranslationRequest {
   createdAt: String!
   locale: String!
   completedAt: String
+  estimatedTime: Int
 }

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -7,3 +7,13 @@ type Product {
   locale: String
   linkId: String
 }
+
+type ProductTranslationRequest {
+  requestId: String!
+  requestedBy: String!
+  categoryId: String!
+  error: Boolean
+  createdAt: String!
+  locale: String!
+  completedAt: String
+}

--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,9 @@
         "host": "portal.vtexcommercestable.com.br",
         "path": "/api/catalog_system/*"
       }
+    },
+    {
+      "name": "vbase-read-write"
     }
   ],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/node/resolvers/product.ts
+++ b/node/resolvers/product.ts
@@ -1,7 +1,12 @@
 import { VBase } from '@vtex/api'
 
 import { CatalogGQL } from '../clients/catalogGQL'
-import { pacer, BUCKET_NAME, ALL_TRANSLATIONS_FILES } from '../utils'
+import {
+  pacer,
+  BUCKET_NAME,
+  ALL_TRANSLATIONS_FILES,
+  calculateExportProcessTime,
+} from '../utils'
 
 export const Product = {
   locale: (
@@ -110,12 +115,13 @@ const productTranslations = async (
     updateRequests
   )
 
-  const requestInfo = {
+  const requestInfo: ProductTranslationRequest = {
     requestId,
     requestedBy: email,
     categoryId,
     locale,
     createdAt: new Date(),
+    estimatedTime: calculateExportProcessTime(productIdCollection.length),
   }
 
   await vbase.saveJSON<ProductTranslationRequest>(

--- a/node/resolvers/product.ts
+++ b/node/resolvers/product.ts
@@ -92,8 +92,6 @@ const productTranslations = async (
 
   const { locale, categoryId } = args
 
-  ctx.state.locale = locale
-
   const productIdCollection = await catalog.getAllProducts(categoryId)
 
   const allTranslationRequest = await vbase.getJSON<string[]>(
@@ -103,7 +101,7 @@ const productTranslations = async (
   )
 
   const updateRequests = allTranslationRequest
-    ? [...allTranslationRequest, requestId]
+    ? [requestId, ...allTranslationRequest]
     : [requestId]
 
   await vbase.saveJSON<string[]>(
@@ -137,6 +135,36 @@ const productTranslations = async (
   return requestInfo
 }
 
+const translationRequests = (_root: unknown, _args: unknown, ctx: Context) =>
+  ctx.clients.vbase.getJSON(BUCKET_NAME, ALL_TRANSLATIONS_FILES, true)
+
+const translationRequestInfo = (
+  _root: unknown,
+  args: { requestId: string },
+  ctx: Context
+) => ctx.clients.vbase.getJSON(BUCKET_NAME, args.requestId)
+
+const downloadProductTranslation = async (
+  _root: unknown,
+  args: { requestId: string },
+  ctx: Context
+) => {
+  const {
+    clients: { vbase },
+  } = ctx
+
+  const { translations, locale } = await vbase.getJSON<
+    ProductTranslationRequest
+  >(BUCKET_NAME, args.requestId, true)
+
+  ctx.state.locale = locale
+
+  return translations
+}
+
 export const queries = {
   productTranslations,
+  translationRequests,
+  translationRequestInfo,
+  downloadProductTranslation,
 }

--- a/node/resolvers/product.ts
+++ b/node/resolvers/product.ts
@@ -55,6 +55,7 @@ const saveTranslation = async (
     const updateTranslation = {
       ...translationRequest,
       translations,
+      completedAt: new Date(),
     }
 
     await vbase.saveJSON<ProductTranslationRequest>(
@@ -113,7 +114,6 @@ const productTranslations = async (
 
   const requestInfo = {
     requestId,
-    translations: null,
     requestedBy: email,
     categoryId,
     locale,

--- a/node/resolvers/product.ts
+++ b/node/resolvers/product.ts
@@ -135,10 +135,13 @@ const productTranslations = async (
   return requestInfo
 }
 
-const translationRequests = (_root: unknown, _args: unknown, ctx: Context) =>
-  ctx.clients.vbase.getJSON(BUCKET_NAME, ALL_TRANSLATIONS_FILES, true)
+const productTranslationRequests = (
+  _root: unknown,
+  _args: unknown,
+  ctx: Context
+) => ctx.clients.vbase.getJSON(BUCKET_NAME, ALL_TRANSLATIONS_FILES, true)
 
-const translationRequestInfo = (
+const productTranslationRequestInfo = (
   _root: unknown,
   args: { requestId: string },
   ctx: Context
@@ -164,7 +167,7 @@ const downloadProductTranslation = async (
 
 export const queries = {
   productTranslations,
-  translationRequests,
-  translationRequestInfo,
+  productTranslationRequests,
+  productTranslationRequestInfo,
   downloadProductTranslation,
 }

--- a/node/typings/product.d.ts
+++ b/node/typings/product.d.ts
@@ -22,10 +22,11 @@ interface ProductTranslationResponse {
 
 interface ProductTranslationRequest {
   requestId: string
-  translations: Array<GraphQLResponse<ProductTranslationResponse>> | null
+  translations?: Array<GraphQLResponse<ProductTranslationResponse>> | null
   requestedBy: string
   categoryId: string
   error?: boolean
   createdAt: Date
   locale: string
+  completedAt?: Date
 }

--- a/node/typings/product.d.ts
+++ b/node/typings/product.d.ts
@@ -19,3 +19,13 @@ interface ProductTranslationResponse {
     linkId: string
   }
 }
+
+interface ProductTranslationRequest {
+  requestId: string
+  translations: Array<GraphQLResponse<ProductTranslationResponse>> | null
+  requestedBy: string
+  categoryId: string
+  error?: boolean
+  createdAt: Date
+  locale: string
+}

--- a/node/typings/product.d.ts
+++ b/node/typings/product.d.ts
@@ -29,4 +29,5 @@ interface ProductTranslationRequest {
   createdAt: Date
   locale: string
   completedAt?: Date
+  estimatedTime: number
 }

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -1,6 +1,11 @@
 import { AuthenticationError, ForbiddenError, UserInputError } from '@vtex/api'
 import type { AxiosError } from 'axios'
 
+const CALLS_PER_MINUTE = 1600
+const ONE_MINUTE = 60 * 1000
+export const BUCKET_NAME = 'product-translation'
+export const ALL_TRANSLATIONS_FILES = 'all-translations'
+
 export const statusToError = (e: AxiosError) => {
   if (!e.response) {
     throw e
@@ -45,3 +50,10 @@ export const getInterationPairs = (currentStep: number): number[] => [
 export const extractProductId = (productResponse: Record<string, number[]>) => {
   return Object.keys(productResponse)
 }
+
+export const pacer = () =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      resolve('done')
+    }, ONE_MINUTE / CALLS_PER_MINUTE)
+  })

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -59,4 +59,4 @@ export const pacer = () =>
   })
 
 export const calculateExportProcessTime = (size: number): number =>
-  size * (ONE_MINUTE / CALLS_PER_MINUTE)
+  Math.ceil(size * (ONE_MINUTE / CALLS_PER_MINUTE))

--- a/node/utils.ts
+++ b/node/utils.ts
@@ -57,3 +57,6 @@ export const pacer = () =>
       resolve('done')
     }, ONE_MINUTE / CALLS_PER_MINUTE)
   })
+
+export const calculateExportProcessTime = (size: number): number =>
+  size * (ONE_MINUTE / CALLS_PER_MINUTE)

--- a/react/components/ProductTranslation/ExportListItem.tsx
+++ b/react/components/ProductTranslation/ExportListItem.tsx
@@ -15,10 +15,13 @@ const ExportListItem = ({ requestId }: Props) => {
   const [longTimeAgo, setLongTimeAgo] = useState(false)
   const [downloading, setDownloading] = useState(false)
   const [errorDonwloading, setErrorDownloading] = useState(false)
-  const { data, error: errorFetching, startPolling, stopPolling } = useQuery<
-    ProdTransInfoReq,
-    { requestId: string }
-  >(PROD_INFO_REQUEST, {
+  const {
+    data,
+    error: errorFetching,
+    startPolling,
+    stopPolling,
+    refetch,
+  } = useQuery<ProdTransInfoReq, { requestId: string }>(PROD_INFO_REQUEST, {
     variables: {
       requestId,
     },
@@ -42,6 +45,12 @@ const ExportListItem = ({ requestId }: Props) => {
   } = data?.productTranslationRequestInfo ?? {}
 
   const tooLongRef = useRef<any>()
+
+  useEffect(() => {
+    if (!completedAt) {
+      refetch({ requestId })
+    }
+  }, [completedAt, refetch, requestId])
 
   useEffect(() => {
     if (!completedAt && !error && createdAt && estimatedTime) {

--- a/react/components/ProductTranslation/ExportListItem.tsx
+++ b/react/components/ProductTranslation/ExportListItem.tsx
@@ -1,16 +1,18 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useQuery } from 'react-apollo'
 import { FormattedDate, FormattedTime } from 'react-intl'
 import { Progress, ButtonPlain } from 'vtex.styleguide'
 
 import PROD_INFO_REQUEST from '../../graphql/getProdTranslationInfoReq.gql'
+import { hasPast15minutes, FIFTEEN_MINUTES, remainingTime } from '../../utils'
 
 interface Props {
   requestId: string
 }
 
 const ExportListItem = ({ requestId }: Props) => {
-  const { data, error: errorFetching } = useQuery<
+  const [longTimeAgo, setLongTimeAgo] = useState(false)
+  const { data, error: errorFetching, startPolling, stopPolling } = useQuery<
     ProdTransInfoReq,
     { requestId: string }
   >(PROD_INFO_REQUEST, {
@@ -19,11 +21,32 @@ const ExportListItem = ({ requestId }: Props) => {
     },
   })
 
-  // eslint-disable-next-line no-console
-  console.log({ data, errorFetching, requestId })
-
   const { categoryId, locale, requestedBy, createdAt, completedAt, error } =
     data?.productTranslationRequestInfo ?? {}
+
+  const tooLongRef = useRef<any>()
+
+  useEffect(() => {
+    if (!completedAt && !error && createdAt) {
+      if (hasPast15minutes(createdAt)) {
+        stopPolling()
+        setLongTimeAgo(true)
+        return
+      }
+      startPolling(10000)
+      clearTimeout(tooLongRef.current)
+      tooLongRef.current = setTimeout(() => {
+        setLongTimeAgo(true)
+        stopPolling()
+      }, remainingTime(createdAt))
+    }
+    if (completedAt || error) {
+      stopPolling()
+      clearTimeout(tooLongRef.current)
+    }
+
+    return () => stopPolling()
+  }, [completedAt, createdAt, error, startPolling, stopPolling])
 
   return !data || errorFetching ? null : (
     <tr>
@@ -48,7 +71,7 @@ const ExportListItem = ({ requestId }: Props) => {
         ) : null}
       </td>
       <td>
-        {error ? (
+        {error || longTimeAgo ? (
           <p className="c-danger i f7">Error creating file</p>
         ) : completedAt ? (
           <ButtonPlain name="download-file" type="button" onClick={() => {}}>

--- a/react/components/ProductTranslation/ExportListItem.tsx
+++ b/react/components/ProductTranslation/ExportListItem.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { useQuery } from 'react-apollo'
+import { useLazyQuery, useQuery } from 'react-apollo'
 import { FormattedDate, FormattedTime } from 'react-intl'
 import { Progress, ButtonPlain } from 'vtex.styleguide'
 
 import PROD_INFO_REQUEST from '../../graphql/getProdTranslationInfoReq.gql'
-import { hasPast15minutes, FIFTEEN_MINUTES, remainingTime } from '../../utils'
+import DOWNLOAD_PRODUCT_TRANSLATION from '../../graphql/downloadProductTranslations.gql'
+import { hasPast15minutes, remainingTime, parseJSONToXLS } from '../../utils'
 
 interface Props {
   requestId: string
@@ -12,6 +13,8 @@ interface Props {
 
 const ExportListItem = ({ requestId }: Props) => {
   const [longTimeAgo, setLongTimeAgo] = useState(false)
+  const [downloading, setDownloading] = useState(false)
+  const [errorDonwloading, setErrorDownloading] = useState(false)
   const { data, error: errorFetching, startPolling, stopPolling } = useQuery<
     ProdTransInfoReq,
     { requestId: string }
@@ -20,6 +23,13 @@ const ExportListItem = ({ requestId }: Props) => {
       requestId,
     },
   })
+
+  const [
+    startDownload,
+    { data: downloadJson, error: downloadError },
+  ] = useLazyQuery<ProductTranslationDownload, { requestId: string }>(
+    DOWNLOAD_PRODUCT_TRANSLATION
+  )
 
   const { categoryId, locale, requestedBy, createdAt, completedAt, error } =
     data?.productTranslationRequestInfo ?? {}
@@ -48,6 +58,25 @@ const ExportListItem = ({ requestId }: Props) => {
     return () => stopPolling()
   }, [completedAt, createdAt, error, startPolling, stopPolling])
 
+  useEffect(() => {
+    // eslint-disable-next-line vtex/prefer-early-return
+    if (downloadJson && downloading) {
+      parseJSONToXLS(downloadJson.downloadProductTranslation, {
+        fileName: `category-${categoryId}-product-data-${locale}`,
+        sheetName: 'product_data',
+      })
+      setDownloading(false)
+    }
+  }, [categoryId, downloadJson, downloading, locale])
+
+  useEffect(() => {
+    // eslint-disable-next-line vtex/prefer-early-return
+    if (downloadError) {
+      setDownloading(false)
+      setErrorDownloading(true)
+    }
+  }, [downloadError])
+
   return !data || errorFetching ? null : (
     <tr>
       <td>
@@ -71,10 +100,19 @@ const ExportListItem = ({ requestId }: Props) => {
         ) : null}
       </td>
       <td>
-        {error || longTimeAgo ? (
+        {error || longTimeAgo || errorDonwloading ? (
           <p className="c-danger i f7">Error creating file</p>
         ) : completedAt ? (
-          <ButtonPlain name="download-file" type="button" onClick={() => {}}>
+          <ButtonPlain
+            name="download-file"
+            type="button"
+            onClick={() => {
+              startDownload({
+                variables: { requestId },
+              })
+              setDownloading(true)
+            }}
+          >
             Download
           </ButtonPlain>
         ) : (

--- a/react/components/ProductTranslation/ExportListItem.tsx
+++ b/react/components/ProductTranslation/ExportListItem.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { useQuery } from 'react-apollo'
+import { FormattedDate, FormattedTime } from 'react-intl'
+import { Progress, ButtonPlain } from 'vtex.styleguide'
+
+import PROD_INFO_REQUEST from '../../graphql/getProdTranslationInfoReq.gql'
+
+interface Props {
+  requestId: string
+}
+
+const ExportListItem = ({ requestId }: Props) => {
+  const { data, error: errorFetching } = useQuery<
+    ProdTransInfoReq,
+    { requestId: string }
+  >(PROD_INFO_REQUEST, {
+    variables: {
+      requestId,
+    },
+  })
+
+  // eslint-disable-next-line no-console
+  console.log({ data, errorFetching, requestId })
+
+  const { categoryId, locale, requestedBy, createdAt, completedAt, error } =
+    data?.productTranslationRequestInfo ?? {}
+
+  return !data || errorFetching ? null : (
+    <tr>
+      <td>
+        <p>{categoryId}</p>
+      </td>
+      <td>
+        <p>{locale}</p>
+      </td>
+      <td>
+        <p>{requestedBy}</p>
+      </td>
+      <td>
+        {createdAt ? (
+          <span>
+            <p>
+              <FormattedTime value={createdAt} />
+              {' - '}
+              <FormattedDate value={createdAt} />
+            </p>
+          </span>
+        ) : null}
+      </td>
+      <td>
+        {error ? (
+          <p className="c-danger i f7">Error creating file</p>
+        ) : completedAt ? (
+          <ButtonPlain name="download-file" type="button" onClick={() => {}}>
+            Download
+          </ButtonPlain>
+        ) : (
+          <Progress type="steps" steps={['inProgress']} />
+        )}
+      </td>
+    </tr>
+  )
+}
+
+export default ExportListItem

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -1,0 +1,204 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react'
+import {
+  ModalDialog,
+  Alert,
+  AutocompleteInput,
+  Spinner,
+  Tabs,
+  Tab,
+} from 'vtex.styleguide'
+import { useLazyQuery, useQuery } from 'react-apollo'
+
+import { useLocaleSelector } from '../LocaleSelector'
+import GET_PRODUCT_TRANSLATION from '../../graphql/getProductTranslations.gql'
+import GET_CATEGORIES_NAME from '../../graphql/getCategoriesName.gql'
+import { filterSearchCategories, parseJSONToXLS } from '../../utils'
+
+const AUTOCOMPLETE_LIST_SIZE = 6
+
+interface AutocompleteValue {
+  label: string
+  value: string
+}
+
+interface Props {
+  isExportOpen: boolean
+  setIsExportOpen: (open: boolean) => void
+}
+
+const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
+  const [downloading, setDownloading] = useState(false)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [hasError, setHasError] = useState(false)
+  const [showMissingCatId, setShowMissingCatId] = useState(false)
+  const { selectedLocale } = useLocaleSelector()
+  const [tabSelected, setTabSelected] = useState<1 | 2>(1)
+
+  const [selectedCategory, setSelectedCategory] = useState<AutocompleteValue>(
+    {} as AutocompleteValue
+  )
+
+  const {
+    data: categoryInfo,
+    loading: loadingCategoryInfo,
+    error: categoryError,
+  } = useQuery<CategoriesNameAndId>(GET_CATEGORIES_NAME)
+
+  const listOfOptions = filterSearchCategories({
+    categoryList: categoryInfo?.getCategoriesName ?? [],
+    term: searchTerm,
+  })
+
+  const [
+    fetchProductTranslations,
+    { data: productTranslations, error: prodTranslationError },
+  ] = useLazyQuery<ProductTranslations, { locale: string; categoryId: string }>(
+    GET_PRODUCT_TRANSLATION,
+    {
+      context: {
+        headers: {
+          'x-vtex-locale': `${selectedLocale}`,
+        },
+      },
+    }
+  )
+
+  const handleClose = useCallback(() => {
+    setSelectedCategory({} as AutocompleteValue)
+    setIsExportOpen(false)
+    setSearchTerm('')
+    setHasError(false)
+  }, [setIsExportOpen])
+
+  useEffect(() => {
+    // eslint-disable-next-line vtex/prefer-early-return
+    if (productTranslations && downloading) {
+      parseJSONToXLS(productTranslations.productTranslations, {
+        fileName: `category-${selectedCategory.value}-product-data-${selectedLocale}`,
+        sheetName: 'product_data',
+      })
+
+      setDownloading(false)
+      handleClose()
+    }
+  }, [
+    productTranslations,
+    selectedLocale,
+    downloading,
+    selectedCategory,
+    handleClose,
+  ])
+
+  useEffect(() => {
+    // eslint-disable-next-line vtex/prefer-early-return
+    if (prodTranslationError || categoryError) {
+      setDownloading(false)
+      setHasError(true)
+    }
+  }, [prodTranslationError, categoryError])
+
+  const downloadProducts = () => {
+    if (!selectedCategory.value) {
+      setShowMissingCatId(true)
+      return
+    }
+    setDownloading(true)
+    fetchProductTranslations({
+      variables: { locale: selectedLocale, categoryId: selectedCategory.value },
+    })
+  }
+
+  const alertRef = useRef<any>()
+
+  useEffect(() => {
+    clearTimeout(alertRef.current)
+    if (showMissingCatId) {
+      alertRef.current = setTimeout(() => {
+        setShowMissingCatId(false)
+      }, 5000)
+    }
+  }, [showMissingCatId])
+
+  return (
+    <ModalDialog
+      isOpen={isExportOpen}
+      loading={downloading}
+      cancelation={{
+        label: 'Cancel',
+        onClick: handleClose,
+      }}
+      confirmation={{
+        label: 'Export Products',
+        onClick: downloadProducts,
+        disabled: true,
+      }}
+      onClose={handleClose}
+    >
+      {showMissingCatId ? (
+        <div className="relative">
+          <div className="w-100 absolute z-max overflow-hidden top-0 left-0">
+            <Alert type="warning" onClose={() => setShowMissingCatId(false)}>
+              Please select a Category Id
+            </Alert>
+          </div>
+        </div>
+      ) : null}
+      <div style={{ minHeight: '420px' }}>
+        <h3>Export Product Data for {selectedLocale}</h3>
+        {loadingCategoryInfo ? (
+          <Spinner />
+        ) : (
+          <Tabs>
+            <Tab
+              label="Export"
+              active={tabSelected === 1}
+              onClick={() => setTabSelected(1)}
+            >
+              <div>
+                <h4>Select category</h4>
+                <AutocompleteInput
+                  input={{
+                    placeholder: 'Enter category name or id',
+                    onChange: (term: string) => setSearchTerm(term),
+                    onClear: () => {
+                      setSearchTerm('')
+                      setSelectedCategory({} as AutocompleteValue)
+                    },
+                    value: searchTerm,
+                  }}
+                  options={{
+                    onSelect: (selectedItem: AutocompleteValue) =>
+                      setSelectedCategory(selectedItem),
+                    value: !searchTerm.length
+                      ? []
+                      : listOfOptions.slice(0, AUTOCOMPLETE_LIST_SIZE),
+                    loading: listOfOptions.length > AUTOCOMPLETE_LIST_SIZE,
+                  }}
+                />
+                <p className="i f7">
+                  Currently, the app allows to export 1.600 products every 3
+                  minutes
+                </p>
+                {hasError ? (
+                  <p className="absolute c-danger i-s bottom-0-m right-0-m mr8">
+                    There was an error exporting products. Please try again in a
+                    few minutes.
+                  </p>
+                ) : null}
+              </div>
+            </Tab>
+            <Tab
+              label="See Files"
+              active={tabSelected === 2}
+              onClick={() => setTabSelected(2)}
+            >
+              <div>Tab two</div>
+            </Tab>
+          </Tabs>
+        )}
+      </div>
+    </ModalDialog>
+  )
+}
+
+export default ProductExportModal

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -17,6 +17,7 @@ import { filterSearchCategories } from '../../utils'
 import ExportListItem from './ExportListItem'
 
 const AUTOCOMPLETE_LIST_SIZE = 6
+const DOWNLOAD_LIST_SIZE = 6
 
 interface AutocompleteValue {
   label: string
@@ -204,11 +205,11 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
                   </tr>
                 </thead>
                 <tbody>
-                  {translationRequests?.productTranslationRequests.map(
-                    (requestId) => (
+                  {translationRequests?.productTranslationRequests
+                    .slice(0, DOWNLOAD_LIST_SIZE)
+                    .map((requestId) => (
                       <ExportListItem key={requestId} requestId={requestId} />
-                    )
-                  )}
+                    ))}
                 </tbody>
               </table>
             </Tab>

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -64,8 +64,6 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
       },
     },
   })
-  // eslint-disable-next-line no-console
-  console.log({ productTranslationInfo })
 
   const { data: translationRequests, updateQuery } = useQuery<
     ProdTranslationRequests
@@ -88,9 +86,6 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
       setTabSelected(2)
     }
   }, [productTranslationInfo, updateQuery])
-
-  // eslint-disable-next-line no-console
-  console.log({ translationRequests })
 
   const handleClose = useCallback(() => {
     setSelectedCategory({} as AutocompleteValue)

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -52,17 +52,18 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
   const [
     fetchProductTranslations,
     { data: productTranslations, error: prodTranslationError },
-  ] = useLazyQuery<ProductTranslations, { locale: string; categoryId: string }>(
-    GET_PRODUCT_TRANSLATION,
-    {
-      context: {
-        headers: {
-          'x-vtex-locale': `${selectedLocale}`,
-        },
+  ] = useLazyQuery<
+    ProductTranslationRequest,
+    { locale: string; categoryId: string }
+  >(GET_PRODUCT_TRANSLATION, {
+    context: {
+      headers: {
+        'x-vtex-locale': `${selectedLocale}`,
       },
-    }
-  )
-
+    },
+  })
+  // eslint-disable-next-line no-console
+  console.log({ productTranslations })
   const handleClose = useCallback(() => {
     setSelectedCategory({} as AutocompleteValue)
     setIsExportOpen(false)
@@ -70,24 +71,24 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
     setHasError(false)
   }, [setIsExportOpen])
 
-  useEffect(() => {
-    // eslint-disable-next-line vtex/prefer-early-return
-    if (productTranslations && downloading) {
-      parseJSONToXLS(productTranslations.productTranslations, {
-        fileName: `category-${selectedCategory.value}-product-data-${selectedLocale}`,
-        sheetName: 'product_data',
-      })
+  // useEffect(() => {
+  //   // eslint-disable-next-line vtex/prefer-early-return
+  //   if (productTranslations && downloading) {
+  //     parseJSONToXLS(productTranslations.productTranslations, {
+  //       fileName: `category-${selectedCategory.value}-product-data-${selectedLocale}`,
+  //       sheetName: 'product_data',
+  //     })
 
-      setDownloading(false)
-      handleClose()
-    }
-  }, [
-    productTranslations,
-    selectedLocale,
-    downloading,
-    selectedCategory,
-    handleClose,
-  ])
+  //     setDownloading(false)
+  //     handleClose()
+  //   }
+  // }, [
+  //   productTranslations,
+  //   selectedLocale,
+  //   downloading,
+  //   selectedCategory,
+  //   handleClose,
+  // ])
 
   useEffect(() => {
     // eslint-disable-next-line vtex/prefer-early-return

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -13,7 +13,7 @@ import { useLocaleSelector } from '../LocaleSelector'
 import START_PRODUCT_TRANSLATION from '../../graphql/startProductTranslations.gql'
 import GET_CATEGORIES_NAME from '../../graphql/getCategoriesName.gql'
 import PROD_TRANSLATION_REQUESTS from '../../graphql/getProductTranslationRequests.gql'
-import { filterSearchCategories, parseJSONToXLS } from '../../utils'
+import { filterSearchCategories } from '../../utils'
 import ExportListItem from './ExportListItem'
 
 const AUTOCOMPLETE_LIST_SIZE = 6
@@ -74,6 +74,7 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
   useEffect(() => {
     const { requestId } = productTranslationInfo?.productTranslations ?? {}
 
+    // eslint-disable-next-line vtex/prefer-early-return
     if (requestId) {
       updateQuery((prevResult) => {
         return {
@@ -83,6 +84,8 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
           ],
         }
       })
+      setDownloading(false)
+      setTabSelected(2)
     }
   }, [productTranslationInfo, updateQuery])
 
@@ -95,25 +98,6 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
     setSearchTerm('')
     setHasError(false)
   }, [setIsExportOpen])
-
-  // useEffect(() => {
-  //   // eslint-disable-next-line vtex/prefer-early-return
-  //   if (productTranslations && downloading) {
-  //     parseJSONToXLS(productTranslations.productTranslations, {
-  //       fileName: `category-${selectedCategory.value}-product-data-${selectedLocale}`,
-  //       sheetName: 'product_data',
-  //     })
-
-  //     setDownloading(false)
-  //     handleClose()
-  //   }
-  // }, [
-  //   productTranslations,
-  //   selectedLocale,
-  //   downloading,
-  //   selectedCategory,
-  //   handleClose,
-  // ])
 
   useEffect(() => {
     // eslint-disable-next-line vtex/prefer-early-return
@@ -201,10 +185,6 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
                     loading: listOfOptions.length > AUTOCOMPLETE_LIST_SIZE,
                   }}
                 />
-                <p className="i f7">
-                  Currently, the app allows to export 1.600 products every 3
-                  minutes
-                </p>
                 {hasError ? (
                   <p className="absolute c-danger i-s bottom-0-m right-0-m mr8">
                     There was an error exporting products. Please try again in a

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -10,9 +10,11 @@ import {
 import { useLazyQuery, useQuery } from 'react-apollo'
 
 import { useLocaleSelector } from '../LocaleSelector'
-import GET_PRODUCT_TRANSLATION from '../../graphql/getProductTranslations.gql'
+import START_PRODUCT_TRANSLATION from '../../graphql/startProductTranslations.gql'
 import GET_CATEGORIES_NAME from '../../graphql/getCategoriesName.gql'
+import PROD_TRANSLATION_REQUESTS from '../../graphql/getProductTranslationRequests.gql'
 import { filterSearchCategories, parseJSONToXLS } from '../../utils'
+import ExportListItem from './ExportListItem'
 
 const AUTOCOMPLETE_LIST_SIZE = 6
 
@@ -55,7 +57,7 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
   ] = useLazyQuery<
     ProductTranslationRequest,
     { locale: string; categoryId: string }
-  >(GET_PRODUCT_TRANSLATION, {
+  >(START_PRODUCT_TRANSLATION, {
     context: {
       headers: {
         'x-vtex-locale': `${selectedLocale}`,
@@ -64,6 +66,14 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
   })
   // eslint-disable-next-line no-console
   console.log({ productTranslations })
+
+  const { data: translationRequests } = useQuery<ProdTranslationRequests>(
+    PROD_TRANSLATION_REQUESTS
+  )
+
+  // eslint-disable-next-line no-console
+  console.log({ translationRequests })
+
   const handleClose = useCallback(() => {
     setSelectedCategory({} as AutocompleteValue)
     setIsExportOpen(false)
@@ -193,7 +203,20 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
               active={tabSelected === 2}
               onClick={() => setTabSelected(2)}
             >
-              <div>Tab two</div>
+              <table className="w-100 mt7 tc">
+                <tr>
+                  <th>CategoryId</th>
+                  <th>Locale</th>
+                  <th>Requested by</th>
+                  <th>Requested At</th>
+                  <th>Download</th>
+                </tr>
+                {translationRequests?.productTranslationRequests.map(
+                  (requestId) => (
+                    <ExportListItem key={requestId} requestId={requestId} />
+                  )
+                )}
+              </table>
             </Tab>
           </Tabs>
         )}

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -178,7 +178,9 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
                     value: !searchTerm.length
                       ? []
                       : listOfOptions.slice(0, AUTOCOMPLETE_LIST_SIZE),
-                    loading: listOfOptions.length > AUTOCOMPLETE_LIST_SIZE,
+                    loading:
+                      searchTerm.length > 0 &&
+                      listOfOptions.length > AUTOCOMPLETE_LIST_SIZE,
                   }}
                 />
                 {hasError ? (

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -67,9 +67,24 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
   // eslint-disable-next-line no-console
   console.log({ productTranslations })
 
-  const { data: translationRequests } = useQuery<ProdTranslationRequests>(
-    PROD_TRANSLATION_REQUESTS
-  )
+  const { data: translationRequests, updateQuery } = useQuery<
+    ProdTranslationRequests
+  >(PROD_TRANSLATION_REQUESTS)
+
+  useEffect(() => {
+    const { requestId } = productTranslations?.productTranslations ?? {}
+
+    if (requestId) {
+      updateQuery((prevResult) => {
+        return {
+          productTranslationRequests: [
+            requestId,
+            ...prevResult.productTranslationRequests,
+          ],
+        }
+      })
+    }
+  }, [productTranslations, updateQuery])
 
   // eslint-disable-next-line no-console
   console.log({ translationRequests })
@@ -204,18 +219,22 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
               onClick={() => setTabSelected(2)}
             >
               <table className="w-100 mt7 tc">
-                <tr>
-                  <th>CategoryId</th>
-                  <th>Locale</th>
-                  <th>Requested by</th>
-                  <th>Requested At</th>
-                  <th>Download</th>
-                </tr>
-                {translationRequests?.productTranslationRequests.map(
-                  (requestId) => (
-                    <ExportListItem key={requestId} requestId={requestId} />
-                  )
-                )}
+                <thead>
+                  <tr>
+                    <th>CategoryId</th>
+                    <th>Locale</th>
+                    <th>Requested by</th>
+                    <th>Requested At</th>
+                    <th>Download</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {translationRequests?.productTranslationRequests.map(
+                    (requestId) => (
+                      <ExportListItem key={requestId} requestId={requestId} />
+                    )
+                  )}
+                </tbody>
               </table>
             </Tab>
           </Tabs>

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -206,7 +206,7 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
                 </thead>
                 <tbody>
                   {translationRequests?.productTranslationRequests
-                    .slice(0, DOWNLOAD_LIST_SIZE)
+                    ?.slice(0, DOWNLOAD_LIST_SIZE)
                     .map((requestId) => (
                       <ExportListItem key={requestId} requestId={requestId} />
                     ))}

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -194,6 +194,10 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
               active={tabSelected === 2}
               onClick={() => setTabSelected(2)}
             >
+              <p className="i f7 tr">
+                The process to translate can take a while. You can leave the
+                page and check it latter.
+              </p>
               <table className="w-100 mt7 tc">
                 <thead>
                   <tr>

--- a/react/components/ProductTranslation/ProductExportModal.tsx
+++ b/react/components/ProductTranslation/ProductExportModal.tsx
@@ -52,8 +52,8 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
   })
 
   const [
-    fetchProductTranslations,
-    { data: productTranslations, error: prodTranslationError },
+    triggerProductTranslations,
+    { data: productTranslationInfo, error: prodTranslationError },
   ] = useLazyQuery<
     ProductTranslationRequest,
     { locale: string; categoryId: string }
@@ -65,14 +65,14 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
     },
   })
   // eslint-disable-next-line no-console
-  console.log({ productTranslations })
+  console.log({ productTranslationInfo })
 
   const { data: translationRequests, updateQuery } = useQuery<
     ProdTranslationRequests
   >(PROD_TRANSLATION_REQUESTS)
 
   useEffect(() => {
-    const { requestId } = productTranslations?.productTranslations ?? {}
+    const { requestId } = productTranslationInfo?.productTranslations ?? {}
 
     if (requestId) {
       updateQuery((prevResult) => {
@@ -84,7 +84,7 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
         }
       })
     }
-  }, [productTranslations, updateQuery])
+  }, [productTranslationInfo, updateQuery])
 
   // eslint-disable-next-line no-console
   console.log({ translationRequests })
@@ -123,13 +123,13 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
     }
   }, [prodTranslationError, categoryError])
 
-  const downloadProducts = () => {
+  const startDownloadProducts = () => {
     if (!selectedCategory.value) {
       setShowMissingCatId(true)
       return
     }
     setDownloading(true)
-    fetchProductTranslations({
+    triggerProductTranslations({
       variables: { locale: selectedLocale, categoryId: selectedCategory.value },
     })
   }
@@ -155,7 +155,7 @@ const ProductExportModal = ({ isExportOpen, setIsExportOpen }: Props) => {
       }}
       confirmation={{
         label: 'Export Products',
-        onClick: downloadProducts,
+        onClick: startDownloadProducts,
         disabled: true,
       }}
       onClose={handleClose}

--- a/react/components/ProductTranslation/ProductTranslation.tsx
+++ b/react/components/ProductTranslation/ProductTranslation.tsx
@@ -1,44 +1,21 @@
-import React, { FC, SyntheticEvent, useEffect, useState, useRef } from 'react'
+import React, { FC, SyntheticEvent, useState } from 'react'
 import {
   InputSearch,
   PageBlock,
   Spinner,
   ButtonWithIcon,
   IconDownload,
-  ModalDialog,
-  AutocompleteInput,
-  Alert,
-  Tabs,
-  Tab,
 } from 'vtex.styleguide'
-import { useLazyQuery, useQuery } from 'react-apollo'
 
 import { useLocaleSelector } from '../LocaleSelector'
 import getProductQuery from '../../graphql/getProduct.gql'
 import ProductForm from './ProductForm'
 import ErrorHandler from '../ErrorHandler'
 import useCatalogQuery from '../../hooks/useCatalogQuery'
-import GET_CATEGORIES_NAME from '../../graphql/getCategoriesName.gql'
-import { filterSearchCategories, parseJSONToXLS } from '../../utils'
-import GET_PRODUCT_TRANSLATION from '../../graphql/getProductTranslations.gql'
-
-const AUTOCOMPLETE_LIST_SIZE = 6
-
-interface AutocompleteValue {
-  label: string
-  value: string
-}
+import ProductExportModal from './ProductExportModal'
 
 const ProductTranslation: FC = () => {
   const [isExportOpen, setIsExportOpen] = useState(false)
-  const [searchTerm, setSearchTerm] = useState('')
-  const [selectedCategory, setSelectedCategory] = useState<AutocompleteValue>(
-    {} as AutocompleteValue
-  )
-  const [downloading, setDownloading] = useState(false)
-  const [showMissingCatId, setShowMissingCatId] = useState(false)
-  const [hasError, setHasError] = useState(false)
-  const [tabSelected, setTabSelected] = useState<1 | 2>(1)
 
   const {
     entryInfo,
@@ -56,31 +33,6 @@ const ProductTranslation: FC = () => {
 
   const { selectedLocale, isXVtexTenant } = useLocaleSelector()
 
-  const [
-    fetchProductTranslations,
-    { data: productTranslations, error: prodTranslationError },
-  ] = useLazyQuery<ProductTranslations, { locale: string; categoryId: string }>(
-    GET_PRODUCT_TRANSLATION,
-    {
-      context: {
-        headers: {
-          'x-vtex-locale': `${selectedLocale}`,
-        },
-      },
-    }
-  )
-
-  const {
-    data: categoryInfo,
-    loading: loadingCategoryInfo,
-    error: categoryError,
-  } = useQuery<CategoriesNameAndId>(GET_CATEGORIES_NAME)
-
-  const listOfOptions = filterSearchCategories({
-    categoryList: categoryInfo?.getCategoriesName ?? [],
-    term: searchTerm,
-  })
-
   const handleSubmitProductId = (e: SyntheticEvent) => {
     e.preventDefault()
     if (!entryId) {
@@ -91,56 +43,6 @@ const ProductTranslation: FC = () => {
       variables: { identifier: { field: 'id', value: entryId } },
     })
   }
-
-  const downloadProducts = () => {
-    if (!selectedCategory.value) {
-      setShowMissingCatId(true)
-      return
-    }
-    setDownloading(true)
-    fetchProductTranslations({
-      variables: { locale: selectedLocale, categoryId: selectedCategory.value },
-    })
-  }
-
-  const handleClose = () => {
-    setSelectedCategory({} as AutocompleteValue)
-    setIsExportOpen(false)
-    setSearchTerm('')
-    setHasError(false)
-  }
-
-  useEffect(() => {
-    // eslint-disable-next-line vtex/prefer-early-return
-    if (productTranslations && downloading) {
-      parseJSONToXLS(productTranslations.productTranslations, {
-        fileName: `category-${selectedCategory.value}-product-data-${selectedLocale}`,
-        sheetName: 'product_data',
-      })
-
-      setDownloading(false)
-      handleClose()
-    }
-  }, [productTranslations, selectedLocale, downloading, selectedCategory])
-
-  const alertRef = useRef<any>()
-
-  useEffect(() => {
-    clearTimeout(alertRef.current)
-    if (showMissingCatId) {
-      alertRef.current = setTimeout(() => {
-        setShowMissingCatId(false)
-      }, 5000)
-    }
-  }, [showMissingCatId])
-
-  useEffect(() => {
-    // eslint-disable-next-line vtex/prefer-early-return
-    if (prodTranslationError || categoryError) {
-      setDownloading(false)
-      setHasError(true)
-    }
-  }, [prodTranslationError, categoryError])
 
   const { id, ...productInfo } = entryInfo?.product || ({} as Product)
 
@@ -196,84 +98,10 @@ const ProductTranslation: FC = () => {
           </PageBlock>
         ) : null}
       </main>
-      <ModalDialog
-        isOpen={isExportOpen}
-        loading={downloading}
-        cancelation={{
-          label: 'Cancel',
-          onClick: handleClose,
-        }}
-        confirmation={{
-          label: 'Export Products',
-          onClick: downloadProducts,
-          disabled: true,
-        }}
-        onClose={handleClose}
-      >
-        {showMissingCatId ? (
-          <div className="relative">
-            <div className="w-100 absolute z-max overflow-hidden top-0 left-0">
-              <Alert type="warning" onClose={() => setShowMissingCatId(false)}>
-                Please select a Category Id
-              </Alert>
-            </div>
-          </div>
-        ) : null}
-        <div style={{ minHeight: '420px' }}>
-          <h3>Export Product Data for {selectedLocale}</h3>
-          {loadingCategoryInfo ? (
-            <Spinner />
-          ) : (
-            <Tabs>
-              <Tab
-                label="Export"
-                active={tabSelected === 1}
-                onClick={() => setTabSelected(1)}
-              >
-                <div>
-                  <h4>Select category</h4>
-                  <AutocompleteInput
-                    input={{
-                      placeholder: 'Enter category name or id',
-                      onChange: (term: string) => setSearchTerm(term),
-                      onClear: () => {
-                        setSearchTerm('')
-                        setSelectedCategory({} as AutocompleteValue)
-                      },
-                      value: searchTerm,
-                    }}
-                    options={{
-                      onSelect: (selectedItem: AutocompleteValue) =>
-                        setSelectedCategory(selectedItem),
-                      value: !searchTerm.length
-                        ? []
-                        : listOfOptions.slice(0, AUTOCOMPLETE_LIST_SIZE),
-                      loading: listOfOptions.length > AUTOCOMPLETE_LIST_SIZE,
-                    }}
-                  />
-                  <p className="i f7">
-                    Currently, the app allows to export 1.600 products every 3
-                    minutes
-                  </p>
-                  {hasError ? (
-                    <p className="absolute c-danger i-s bottom-0-m right-0-m mr8">
-                      There was an error exporting products. Please try again in
-                      a few minutes.
-                    </p>
-                  ) : null}
-                </div>
-              </Tab>
-              <Tab
-                label="See Files"
-                active={tabSelected === 2}
-                onClick={() => setTabSelected(2)}
-              >
-                <div>Tab two</div>
-              </Tab>
-            </Tabs>
-          )}
-        </div>
-      </ModalDialog>
+      <ProductExportModal
+        isExportOpen={isExportOpen}
+        setIsExportOpen={setIsExportOpen}
+      />
     </>
   )
 }

--- a/react/components/ProductTranslation/ProductTranslation.tsx
+++ b/react/components/ProductTranslation/ProductTranslation.tsx
@@ -1,4 +1,4 @@
-import React, { FC, SyntheticEvent, useState } from 'react'
+import React, { SyntheticEvent } from 'react'
 import { InputSearch, PageBlock, Spinner } from 'vtex.styleguide'
 
 import { useLocaleSelector } from '../LocaleSelector'
@@ -8,9 +8,10 @@ import ErrorHandler from '../ErrorHandler'
 import useCatalogQuery from '../../hooks/useCatalogQuery'
 import ProductExportModal from './ProductExportModal'
 
-const ProductTranslation: FC = () => {
-  const [isExportOpen, setIsExportOpen] = useState(false)
-
+const ProductTranslation = ({
+  isExportOpen = false,
+  handleOpenExport = () => {},
+}: ComponentProps) => {
   const {
     entryInfo,
     isLoadingOrRefetching,
@@ -81,7 +82,7 @@ const ProductTranslation: FC = () => {
       </main>
       <ProductExportModal
         isExportOpen={isExportOpen}
-        setIsExportOpen={setIsExportOpen}
+        setIsExportOpen={handleOpenExport}
       />
     </>
   )

--- a/react/components/ProductTranslation/ProductTranslation.tsx
+++ b/react/components/ProductTranslation/ProductTranslation.tsx
@@ -8,6 +8,8 @@ import {
   ModalDialog,
   AutocompleteInput,
   Alert,
+  Tabs,
+  Tab,
 } from 'vtex.styleguide'
 import { useLazyQuery, useQuery } from 'react-apollo'
 
@@ -36,6 +38,7 @@ const ProductTranslation: FC = () => {
   const [downloading, setDownloading] = useState(false)
   const [showMissingCatId, setShowMissingCatId] = useState(false)
   const [hasError, setHasError] = useState(false)
+  const [tabSelected, setTabSelected] = useState<1 | 2>(1)
 
   const {
     entryInfo,
@@ -221,38 +224,53 @@ const ProductTranslation: FC = () => {
           {loadingCategoryInfo ? (
             <Spinner />
           ) : (
-            <div>
-              <h4>Select category</h4>
-              <AutocompleteInput
-                input={{
-                  placeholder: 'Enter category name or id',
-                  onChange: (term: string) => setSearchTerm(term),
-                  onClear: () => {
-                    setSearchTerm('')
-                    setSelectedCategory({} as AutocompleteValue)
-                  },
-                  value: searchTerm,
-                }}
-                options={{
-                  onSelect: (selectedItem: AutocompleteValue) =>
-                    setSelectedCategory(selectedItem),
-                  value: !searchTerm.length
-                    ? []
-                    : listOfOptions.slice(0, AUTOCOMPLETE_LIST_SIZE),
-                  loading: listOfOptions.length > AUTOCOMPLETE_LIST_SIZE,
-                }}
-              />
-              <p className="i f7">
-                Currently, the app allows to export 1.600 products every 3
-                minutes
-              </p>
-              {hasError ? (
-                <p className="absolute c-danger i-s bottom-0-m right-0-m mr8">
-                  There was an error exporting products. Please try again in a
-                  few minutes.
-                </p>
-              ) : null}
-            </div>
+            <Tabs>
+              <Tab
+                label="Export"
+                active={tabSelected === 1}
+                onClick={() => setTabSelected(1)}
+              >
+                <div>
+                  <h4>Select category</h4>
+                  <AutocompleteInput
+                    input={{
+                      placeholder: 'Enter category name or id',
+                      onChange: (term: string) => setSearchTerm(term),
+                      onClear: () => {
+                        setSearchTerm('')
+                        setSelectedCategory({} as AutocompleteValue)
+                      },
+                      value: searchTerm,
+                    }}
+                    options={{
+                      onSelect: (selectedItem: AutocompleteValue) =>
+                        setSelectedCategory(selectedItem),
+                      value: !searchTerm.length
+                        ? []
+                        : listOfOptions.slice(0, AUTOCOMPLETE_LIST_SIZE),
+                      loading: listOfOptions.length > AUTOCOMPLETE_LIST_SIZE,
+                    }}
+                  />
+                  <p className="i f7">
+                    Currently, the app allows to export 1.600 products every 3
+                    minutes
+                  </p>
+                  {hasError ? (
+                    <p className="absolute c-danger i-s bottom-0-m right-0-m mr8">
+                      There was an error exporting products. Please try again in
+                      a few minutes.
+                    </p>
+                  ) : null}
+                </div>
+              </Tab>
+              <Tab
+                label="See Files"
+                active={tabSelected === 2}
+                onClick={() => setTabSelected(2)}
+              >
+                <div>Tab two</div>
+              </Tab>
+            </Tabs>
           )}
         </div>
       </ModalDialog>

--- a/react/graphql/downloadProductTranslations.gql
+++ b/react/graphql/downloadProductTranslations.gql
@@ -1,0 +1,12 @@
+query downloadProductTranslations($requestId: String!) {
+  downloadProductTranslation(requestId: $requestId)
+    @context(provider: "vtex.admin-catalog-translation") {
+    id
+    name
+    description
+    shortDescription
+    title
+    locale
+    linkId
+  }
+}

--- a/react/graphql/getProdTranslationInfoReq.gql
+++ b/react/graphql/getProdTranslationInfoReq.gql
@@ -1,0 +1,11 @@
+query getProdTransInfoReq($requestId: String!) {
+  productTranslationRequestInfo(requestId: $requestId) {
+    requestId
+    requestedBy
+    categoryId
+    error
+    createdAt
+    locale
+    completedAt
+  }
+}

--- a/react/graphql/getProdTranslationInfoReq.gql
+++ b/react/graphql/getProdTranslationInfoReq.gql
@@ -7,5 +7,6 @@ query getProdTransInfoReq($requestId: String!) {
     createdAt
     locale
     completedAt
+    estimatedTime
   }
 }

--- a/react/graphql/getProductTranslationRequests.gql
+++ b/react/graphql/getProductTranslationRequests.gql
@@ -1,0 +1,4 @@
+query getProdTranslationRequests {
+  productTranslationRequests
+    @context(provider: "vtex.admin-catalog-translation")
+}

--- a/react/graphql/getProductTranslations.gql
+++ b/react/graphql/getProductTranslations.gql
@@ -1,12 +1,6 @@
 query getProductTranslations($locale: String!, $categoryId: String!) {
   productTranslations(locale: $locale, categoryId: $categoryId)
     @context(provider: "vtex.admin-catalog-translation") {
-    id
-    name
-    description
-    shortDescription
-    title
-    linkId
-    locale
+    requestId
   }
 }

--- a/react/graphql/startProductTranslations.gql
+++ b/react/graphql/startProductTranslations.gql
@@ -1,4 +1,4 @@
-query getProductTranslations($locale: String!, $categoryId: String!) {
+query startProductTranslations($locale: String!, $categoryId: String!) {
   productTranslations(locale: $locale, categoryId: $categoryId)
     @context(provider: "vtex.admin-catalog-translation") {
     requestId

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -66,13 +66,14 @@ interface CategoriesNameAndId {
   getCategoriesName: Array<{ id: string; name: string }>
 }
 
-interface ProductTranslations {
-  productTranslations: Array<{
-    id: string
-    name: string
-    description: string
-    shortDescription: string
-    title: string
+interface ProductTranslationRequest {
+  productTranslations: {
+    requestId: string
+    requestedBy: string
+    categoryId: string
+    error: boolean
+    createdAt: Date
     locale: string
-  }>
+    completedAt: Date
+  }
 }

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -74,6 +74,7 @@ interface ProductTranslationRequestInfo {
   createdAt: string
   locale: string
   completedAt: string
+  estimatedTime: number
 }
 
 interface ProductTranslationRequest {

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -71,9 +71,9 @@ interface ProductTranslationRequestInfo {
   requestedBy: string
   categoryId: string
   error: boolean
-  createdAt: Date
+  createdAt: string
   locale: string
-  completedAt: Date
+  completedAt: string
 }
 
 interface ProductTranslationRequest {

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -66,14 +66,24 @@ interface CategoriesNameAndId {
   getCategoriesName: Array<{ id: string; name: string }>
 }
 
+interface ProductTranslationRequestInfo {
+  requestId: string
+  requestedBy: string
+  categoryId: string
+  error: boolean
+  createdAt: Date
+  locale: string
+  completedAt: Date
+}
+
 interface ProductTranslationRequest {
-  productTranslations: {
-    requestId: string
-    requestedBy: string
-    categoryId: string
-    error: boolean
-    createdAt: Date
-    locale: string
-    completedAt: Date
-  }
+  productTranslations: ProductTranslationRequestInfo
+}
+
+interface ProdTranslationRequests {
+  productTranslationRequests: string[]
+}
+
+interface ProdTransInfoReq {
+  productTranslationRequestInfo: ProductTranslationRequestInfo
 }

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -87,3 +87,7 @@ interface ProdTranslationRequests {
 interface ProdTransInfoReq {
   productTranslationRequestInfo: ProductTranslationRequestInfo
 }
+
+interface ProductTranslationDownload {
+  downloadProductTranslation: Product[]
+}

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -79,14 +79,21 @@ export const filterSearchCategories = ({
   )
 }
 
-export const FIFTEEN_MINUTES = 1000 * 60 * 15
+const ESTIMATED_MARGIN = 5
 
-export const hasPast15minutes = (date: string): boolean => {
-  return FIFTEEN_MINUTES < new Date().valueOf() - new Date(date).valueOf()
+export const remainingTime = (date: string, estimatedTime: number): number => {
+  const remaining =
+    estimatedTime * ESTIMATED_MARGIN -
+    (new Date().valueOf() - new Date(date).valueOf())
+  return remaining > 0 ? remaining : 0
 }
 
-export const remainingTime = (date: string): number => {
-  const remaining =
-    FIFTEEN_MINUTES - (new Date().valueOf() - new Date(date).valueOf())
-  return remaining > 0 ? remaining : 0
+export const shouldHaveCompleted = (
+  date: string,
+  estimatedTime: number
+): boolean => {
+  return (
+    estimatedTime * ESTIMATED_MARGIN <
+    new Date().valueOf() - new Date(date).valueOf()
+  )
 }

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -78,3 +78,15 @@ export const filterSearchCategories = ({
       ) ?? []
   )
 }
+
+export const FIFTEEN_MINUTES = 1000 * 60 * 15
+
+export const hasPast15minutes = (date: string): boolean => {
+  return FIFTEEN_MINUTES < new Date().valueOf() - new Date(date).valueOf()
+}
+
+export const remainingTime = (date: string): number => {
+  const remaining =
+    FIFTEEN_MINUTES - new Date().valueOf() - new Date(date).valueOf()
+  return remaining > 0 ? remaining : 0
+}

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -87,6 +87,6 @@ export const hasPast15minutes = (date: string): boolean => {
 
 export const remainingTime = (date: string): number => {
   const remaining =
-    FIFTEEN_MINUTES - new Date().valueOf() - new Date(date).valueOf()
+    FIFTEEN_MINUTES - (new Date().valueOf() - new Date(date).valueOf())
   return remaining > 0 ? remaining : 0
 }


### PR DESCRIPTION
**What problem is this solving?**

<!--- What is the motivation and context for this change? -->
This PR removes the limit of 1600 when creating a file to download product translations. It adds a tab that renders all translation requests, and shows the current status of a file: `processing`, `error` or ready to `downalod`. 

When requesting a new translation, a new line will be added to the panel. If the processing time is too long, user can check the translation out in a latter time. When download is ready, user can clicks the button that will trigger the download.


#### Back end
For the back end, it adds 4 new resolvers:

__productTranslations__:  Used to trigger a translation process. It will calls a function that resolves after the server respond to the client. It updates an object on VBASE that holds all `requestId` in an array, creates an object associated - below - to this `requestId` and sends it to the client as a response.

```ts
interface ProductTranslationRequest {
  requestId: string
  estimatedTime: number // Calculate by multiplying the number of products per the `sleep time` for every call to translate products
  requestedBy: string
  categoryId: string
  error?: boolean
  createdAt: Date
  locale: string
  completedAt?: Date // Update only when the async function translating the products finishes
  translations?: Array<GraphQLResponse<ProductTranslationResponse>> | null // Update only when the async function translating the products finishes
}
```

__productTranslationRequests__: Used to access all requests made to translate products. It holds only the `requestId` in an array.

__productTranslationRequestInfo__: Used to consult the object with the summary of the translation process (above).

__downloadProductTranslation__: Used to resolve the product translation info. Client calls it when the the field `completedAt` has some value.


#### Front end

For the front end, it removes the modal for export from the main component `react/components/ProductTranslation/ProductTranslation.tsx` and brings it to `ProductExportModal.tsx`. 

The best order to review the front end files is: `ProductExportModal.tsx` then `ExportListItem.tsx`

__ProductExportModal.tsx__

In this component is where the trigger to start the process to translate lives. 

The [lazyQuery](https://github.com/vtex-apps/admin-catalog-translations/compare/increase-download-limit?expand=1#diff-8e0898cdd28bea4909f29e0088e1c07c0711f40b3f9e4299e78de57671e8a0d1R55-R67) triggers the translation process, given a locale and category id. 

And this [query](https://github.com/vtex-apps/admin-catalog-translations/compare/increase-download-limit?expand=1#diff-8e0898cdd28bea4909f29e0088e1c07c0711f40b3f9e4299e78de57671e8a0d1R69-R71) fetches all translation requests, used to create the list of files rendered by `ExportListItem.tsx`.

The main [useEffect](https://github.com/vtex-apps/admin-catalog-translations/compare/increase-download-limit?expand=1#diff-8e0898cdd28bea4909f29e0088e1c07c0711f40b3f9e4299e78de57671e8a0d1R73-R89) runs after a request is made and updates the query result that contains all requests id with the new one created. 

__ExportListItem.tsx__

Every request id renders this component. In the first render, it fetches the details for the request [here](https://github.com/vtex-apps/admin-catalog-translations/compare/increase-download-limit?expand=1#diff-9c0312ec6eeb61f6f02602aec03d7c8734c4ae3dc604cae5f59d1b7877d36721R18-R28)

The main [useEffect](https://github.com/vtex-apps/admin-catalog-translations/compare/increase-download-limit?expand=1#diff-9c0312ec6eeb61f6f02602aec03d7c8734c4ae3dc604cae5f59d1b7877d36721R55-R75) is responsible for the logic the start and stop polling for new info when the request detail doesn't have either the `completedAt` or `error` flags. It relays in the `estimation` time to set the polling interval, to calculate if the translations should already have finished and the remaining time until finishing the process. For the latter two, it adds a margin to avoid false negatives.

The small [useEffect](https://github.com/vtex-apps/admin-catalog-translations/compare/increase-download-limit?expand=1#diff-9c0312ec6eeb61f6f02602aec03d7c8734c4ae3dc604cae5f59d1b7877d36721R55-R75) refetches the query if use closes and opens again the modal and the [last one](https://github.com/vtex-apps/admin-catalog-translations/compare/increase-download-limit?expand=1#diff-9c0312ec6eeb61f6f02602aec03d7c8734c4ae3dc604cae5f59d1b7877d36721R77-R86) handles the parse process from json to xlsx after it is downloaded with this [lazyQuery](https://github.com/vtex-apps/admin-catalog-translations/compare/increase-download-limit?expand=1#diff-9c0312ec6eeb61f6f02602aec03d7c8734c4ae3dc604cae5f59d1b7877d36721R30-R35).

**How should this be manually tested?**

1. Visit [this workspace](https://exportproducts--powerplanet.myvtex.com/admin/catalog-translation/product);
2. Select a language different then the main one;
3. Open the `export` modal;
4. Select a category;
5. Click export products;

There should be a new line in the tab `See Files`. If it's a small category (category 222), the file should be ready to be downloaded. If it's a big category (334), the process should take ~3 minutes. One can either wait in the page or close it and check it later.

**Screenshots or example usage:**

<img width="838" alt="Screen Shot 2021-05-06 at 5 26 27 PM" src="https://user-images.githubusercontent.com/38737958/117324609-3c973c00-ae90-11eb-9c96-4f79b55679d0.png">
