### PR TITLE
fix: fixing specification mutation

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -4,7 +4,7 @@
   "main": "index.ts",
   "license": "UNLICENSED",
   "dependencies": {
-    "@vtex/api": "6.43.1"
+    "@vtex/api": "6.44.0"
   },
   "devDependencies": {
     "@vtex/tsconfig": "^0.5.6",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -122,10 +122,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.43.1":
-  version "6.43.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.43.1.tgz#3c69cc23af97d23729f970b332d740041dcc8d2e"
-  integrity sha512-4I7rb+PrXGwmy/ZlYC+wQlWT9nePMdMb3dNJ9wPGMYkAa8J12uA4SeHQP9Uzf+gEYLatliTKzL1cvEYrAR41gg==
+"@vtex/api@6.44.0":
+  version "6.44.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.44.0.tgz#8dc2a27c37635278117310bcc5cd16203c0a5849"
+  integrity sha512-7nPIwzQz55Mu0E1BOoW1noObZet9J34iKmeAJU3TRL7iiGmPZB0McSjC6KgDHkfqYgim2JGrnCsa1978ffbwKQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1199,7 +1199,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/SpecificationsTranslation/SpecificationsForm.tsx
+++ b/react/components/SpecificationsTranslation/SpecificationsForm.tsx
@@ -21,7 +21,6 @@ interface SpecificationsFormProps {
 const SpecificationsForm: FC<SpecificationsFormProps> = ({
   specificationInfo,
   specificationId,
-  updateMemoSpecifications,
 }) => {
   const {
     formState,
@@ -75,17 +74,6 @@ const SpecificationsForm: FC<SpecificationsFormProps> = ({
             label="Name"
             value={formState.name}
             name="name"
-            disabled={isXVtexTenant || !canEdit}
-            onChange={handleInputChange}
-            required
-          />
-        </div>
-        <div className="mb5">
-          <Textarea
-            resize="none"
-            label="Description"
-            value={formState.description}
-            name="description"
             disabled={isXVtexTenant || !canEdit}
             onChange={handleInputChange}
             required

--- a/react/components/SpecificationsTranslation/SpecificationsForm.tsx
+++ b/react/components/SpecificationsTranslation/SpecificationsForm.tsx
@@ -21,6 +21,7 @@ interface SpecificationsFormProps {
 const SpecificationsForm: FC<SpecificationsFormProps> = ({
   specificationInfo,
   specificationId,
+  updateMemoSpecifications,
 }) => {
   const {
     formState,
@@ -28,11 +29,11 @@ const SpecificationsForm: FC<SpecificationsFormProps> = ({
     handleInputChange,
     changed,
     handleToggleEdit,
-  } = useFormTranslation(specificationInfo)
+  } = useFormTranslation<FieldInputTranslation>(specificationInfo)
 
   const { isXVtexTenant, selectedLocale } = useLocaleSelector()
   const [translateSpecification, { loading }] = useMutation<
-    { translateSpecification: boolean },
+    { translateField: boolean },
     { args: Specifications; locale: string }
   >(translateSpecificationMutation)
 
@@ -42,7 +43,7 @@ const SpecificationsForm: FC<SpecificationsFormProps> = ({
     if (loading) {
       return
     }
-    const args = {
+    const SpecificationArgs = {
       ...formState,
       ...{ fieldId: specificationId },
     }
@@ -50,12 +51,15 @@ const SpecificationsForm: FC<SpecificationsFormProps> = ({
       const { data, errors } = await translateSpecification({
         variables: {
           locale: selectedLocale,
-          args,
+          args: SpecificationArgs,
         },
       })
-      const { translateSpecification: translateSpecificationResult } =
-        data ?? {}
+      const { translateField: translateSpecificationResult } = data ?? {}
       if (translateSpecificationResult) {
+        updateMemoSpecifications((state) => ({
+          ...state,
+          ...{ [selectedLocale]: { field: SpecificationArgs } },
+        }))
         openAlert('success', 'Specifications')
       }
       if (errors?.length) {
@@ -76,7 +80,6 @@ const SpecificationsForm: FC<SpecificationsFormProps> = ({
             name="name"
             disabled={isXVtexTenant || !canEdit}
             onChange={handleInputChange}
-            required
           />
         </div>
         {isXVtexTenant ? null : (

--- a/react/graphql/getSpecification.gql
+++ b/react/graphql/getSpecification.gql
@@ -2,8 +2,5 @@ query GetSpecification($fieldId: ID!) {
   field(id: $fieldId) @context(provider: "vtex.catalog-graphql") {
     fieldId
     name
-    description
-    fieldTypeId
-    fieldTypeName
   }
 }

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -58,9 +58,6 @@ interface Specifications extends FieldInputTranslation {
 }
 interface FieldInputTranslation {
   name: string
-  description: string
-  fieldTypeId: string
-  fieldTypeName: string
 }
 interface CategoriesNameAndId {
   getCategoriesName: Array<{ id: string; name: string }>


### PR DESCRIPTION
**What problem is this solving?**

Fixing the mutation for the specification translation. 
Removed some interfaces that were not used and removed some query fields that were also not used. 
**How should this be manually tested?**
It can be tested here:
https://translation--unileverb2b.myvtex.com/admin/catalog-translation/specifications
Specification id: 18


