### PR TITLE
Connect import products

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -17,8 +17,5 @@ type Query {
 }
 
 type Mutation {
-  uploadProductTranslations(
-    products: [ProductTranslationUpload]!
-    locale: String!
-  ): String
+  uploadProductTranslations(products: Upload!, locale: String!): String
 }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -20,5 +20,5 @@ type Mutation {
   uploadProductTranslations(
     products: [ProductTranslationUpload]!
     locale: String!
-  ): Boolean
+  ): String
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -42,5 +42,22 @@
   "catalog-translation.export.modal.table-header.requested.at": "Requested at",
   "catalog-translation.export.modal.table-header.download": "Download",
   "catalog-translation.export.modal.download-list.error": "Error creating file",
-  "catalog-translation.export.modal.download-list.download-btn": "Download"
+  "catalog-translation.export.modal.download-list.download-btn": "Download",
+  "catalog-translation.import.modal.cancelation": "Cancel",
+  "catalog-translation.import.modal.confirmation": "Send Translations",
+  "catalog-translation.import.modal.header": "Import Product Translations for {selectedLocale}",
+  "catalog-translation.import.modal.import-tab": "Import",
+  "catalog-translation.import.modal.request-tab": "Requests",
+  "catalog-translation.import.modal.model-download-button": "Download xlsx model",
+  "catalog-translation.import.modal.dropzone": "Drop here your XLSX or ",
+  "catalog-translation.import.modal.dropzone-choose-file": "choose a file",
+  "catalog-translation.import.modal.total-entries": "total entries",
+  "catalog-translation.import.modal.total-warnings": "warnings",
+  "catalog-translation.import.modal.total-errors": "errors. The entries will be ignored",
+  "catalog-translation.import.modal.error-uploading": "Error uploading translations",
+  "catalog-translation.import.modal.table-header.locale": "Locale",
+  "catalog-translation.import.modal.table-header.translated-by": "Translated by",
+  "catalog-translation.import.modal.table-header.created-at": "Created at",
+  "catalog-translation.import.modal.table-header.progress": "Progress",
+  "catalog-translation.import.modal.table-header.total-translated": "% translated"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -48,7 +48,7 @@
   "catalog-translation.import.modal.header": "Import Product Translations for {selectedLocale}",
   "catalog-translation.import.modal.import-tab": "Import",
   "catalog-translation.import.modal.request-tab": "Requests",
-  "catalog-translation.import.modal.model-download-button": "Download xlsx model",
+  "catalog-translation.import.modal.download-button": "Download xlsx model",
   "catalog-translation.import.modal.dropzone": "Drop here your XLSX or ",
   "catalog-translation.import.modal.dropzone-choose-file": "choose a file",
   "catalog-translation.import.modal.total-entries": "total entries",
@@ -60,5 +60,8 @@
   "catalog-translation.import.modal.table-header.created-at": "Created at",
   "catalog-translation.import.modal.table-header.progress": "Progress",
   "catalog-translation.import.modal.table-header.total-translated": "% translated",
-  "catalog-translation.import.modal.status-list.error": "Error"
+  "catalog-translation.import.modal.status-list.error": "Error",
+  "catalog-translation.import.warning-and-error": "of",
+  "catalog-translation.import.table-header.line": "Line",
+  "catalog-translation.import.table-header.missing-fields": "Missing Fields"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -59,5 +59,6 @@
   "catalog-translation.import.modal.table-header.translated-by": "Translated by",
   "catalog-translation.import.modal.table-header.created-at": "Created at",
   "catalog-translation.import.modal.table-header.progress": "Progress",
-  "catalog-translation.import.modal.table-header.total-translated": "% translated"
+  "catalog-translation.import.modal.table-header.total-translated": "% translated",
+  "catalog-translation.import.modal.status-list.error": "Error"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -51,7 +51,7 @@
   "catalog-translation.import.modal.request-tab": "Requests",
   "catalog-translation.import.modal.download-button": "Download xlsx model",
   "catalog-translation.import.modal.dropzone": "Drop here your XLSX or ",
-  "catalog-translation.import.modal.model-dropzone-choose-file": "choose a file",
+  "catalog-translation.import.modal.dropzone-choose-file": "choose a file",
   "catalog-translation.import.modal.total-entries": "total entries",
   "catalog-translation.import.modal.total-warnings": "warnings",
   "catalog-translation.import.modal.total-errors": "errors. The entries will be ignored",
@@ -61,5 +61,8 @@
   "catalog-translation.import.modal.table-header.created-at": "Created at",
   "catalog-translation.import.modal.table-header.progress": "Progress",
   "catalog-translation.import.modal.table-header.total-translated": "% translated",
-  "catalog-translation.import.modal.status-list.error": "Error"
+  "catalog-translation.import.modal.status-list.error": "Error",
+  "catalog-translation.import.warning-and-error": "of",
+  "catalog-translation.import.table-header.line": "Line",
+  "catalog-translation.import.table-header.missing-fields": "Missing Fields"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -60,5 +60,6 @@
   "catalog-translation.import.modal.table-header.translated-by": "Translated by",
   "catalog-translation.import.modal.table-header.created-at": "Created at",
   "catalog-translation.import.modal.table-header.progress": "Progress",
-  "catalog-translation.import.modal.table-header.total-translated": "% translated"
+  "catalog-translation.import.modal.table-header.total-translated": "% translated",
+  "catalog-translation.import.modal.status-list.error": "Error"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -43,5 +43,22 @@
   "catalog-translation.export.modal.table-header.requested.at": "Requested at",
   "catalog-translation.export.modal.table-header.download": "Download",
   "catalog-translation.export.modal.download-list.error": "Error creating file",
-  "catalog-translation.export.modal.download-list.download-btn": "Download"
+  "catalog-translation.export.modal.download-list.download-btn": "Download",
+  "catalog-translation.import.modal.cancelation": "Cancel",
+  "catalog-translation.import.modal.confirmation": "Send Translations",
+  "catalog-translation.import.modal.header": "Import Product Translations for {selectedLocale}",
+  "catalog-translation.import.modal.import-tab": "Import",
+  "catalog-translation.import.modal.request-tab": "Requests",
+  "catalog-translation.import.modal.download-button": "Download xlsx model",
+  "catalog-translation.import.modal.dropzone": "Drop here your XLSX or ",
+  "catalog-translation.import.modal.model-dropzone-choose-file": "choose a file",
+  "catalog-translation.import.modal.total-entries": "total entries",
+  "catalog-translation.import.modal.total-warnings": "warnings",
+  "catalog-translation.import.modal.total-errors": "errors. The entries will be ignored",
+  "catalog-translation.import.modal.error-uploading": "Error uploading translations",
+  "catalog-translation.import.modal.table-header.locale": "Locale",
+  "catalog-translation.import.modal.table-header.translated-by": "Translated by",
+  "catalog-translation.import.modal.table-header.created-at": "Created at",
+  "catalog-translation.import.modal.table-header.progress": "Progress",
+  "catalog-translation.import.modal.table-header.total-translated": "% translated"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -60,5 +60,6 @@
   "catalog-translation.import.modal.table-header.translated-by": "Traducido por",
   "catalog-translation.import.modal.table-header.created-at": "Creado en",
   "catalog-translation.import.modal.table-header.progress": "Progreso",
-  "catalog-translation.import.modal.table-header.total-translated": "% translated"
+  "catalog-translation.import.modal.table-header.total-translated": "% translated",
+  "catalog-translation.import.modal.status-list.error": "Error"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -46,12 +46,12 @@
   "catalog-translation.export.modal.download-list.download-btn": "Descargar",
   "catalog-translation.import.modal.cancelation": "Cancelar",
   "catalog-translation.import.modal.confirmation": "Enviar Traducciones",
-  "catalog-translation.import.modal.header": "Import Product Translations for {selectedLocale}",
+  "catalog-translation.import.modal.header": "Importar traducciones de productos para {selectedLocale}",
   "catalog-translation.import.modal.import-tab": "Importar",
   "catalog-translation.import.modal.request-tab": "Traducciones",
   "catalog-translation.import.modal.download-button": "Descargar modelo xlsx",
   "catalog-translation.import.modal.dropzone": "Deje aquí su XLSX o ",
-  "catalog-translation.import.modal.model-dropzone-choose-file": "escoge un archivo",
+  "catalog-translation.import.modal.dropzone-choose-file": "escoge un archivo",
   "catalog-translation.import.modal.total-entries": "entradas",
   "catalog-translation.import.modal.total-warnings": "advertencias ",
   "catalog-translation.import.modal.total-errors": "errores. Las entradas serán ignoradas",
@@ -61,5 +61,8 @@
   "catalog-translation.import.modal.table-header.created-at": "Creado en",
   "catalog-translation.import.modal.table-header.progress": "Progreso",
   "catalog-translation.import.modal.table-header.total-translated": "% translated",
-  "catalog-translation.import.modal.status-list.error": "Error"
+  "catalog-translation.import.modal.status-list.error": "Error",
+  "catalog-translation.import.warning-and-error": "de",
+  "catalog-translation.import.table-header.line": "Línea",
+  "catalog-translation.import.table-header.missing-fields": "Campos faltantes"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -43,5 +43,22 @@
   "catalog-translation.export.modal.table-header.requested.at": "Solicitado en",
   "catalog-translation.export.modal.table-header.download": "Descargar",
   "catalog-translation.export.modal.download-list.error": "Error al crear el archivo",
-  "catalog-translation.export.modal.download-list.download-btn": "Descargar"
+  "catalog-translation.export.modal.download-list.download-btn": "Descargar",
+  "catalog-translation.import.modal.cancelation": "Cancelar",
+  "catalog-translation.import.modal.confirmation": "Enviar Traducciones",
+  "catalog-translation.import.modal.header": "Import Product Translations for {selectedLocale}",
+  "catalog-translation.import.modal.import-tab": "Importar",
+  "catalog-translation.import.modal.request-tab": "Traducciones",
+  "catalog-translation.import.modal.download-button": "Descargar modelo xlsx",
+  "catalog-translation.import.modal.dropzone": "Deje aquí su XLSX o ",
+  "catalog-translation.import.modal.model-dropzone-choose-file": "escoge un archivo",
+  "catalog-translation.import.modal.total-entries": "entradas",
+  "catalog-translation.import.modal.total-warnings": "advertencias ",
+  "catalog-translation.import.modal.total-errors": "errores. Las entradas serán ignoradas",
+  "catalog-translation.import.modal.error-uploading": "Error al cargar",
+  "catalog-translation.import.modal.table-header.locale": "Locale",
+  "catalog-translation.import.modal.table-header.translated-by": "Traducido por",
+  "catalog-translation.import.modal.table-header.created-at": "Creado en",
+  "catalog-translation.import.modal.table-header.progress": "Progreso",
+  "catalog-translation.import.modal.table-header.total-translated": "% translated"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -60,5 +60,6 @@
   "catalog-translation.import.modal.table-header.translated-by": "Traduzido por",
   "catalog-translation.import.modal.table-header.created-at": "Criado em",
   "catalog-translation.import.modal.table-header.progress": "Progresso",
-  "catalog-translation.import.modal.table-header.total-translated": "% traduzido"
+  "catalog-translation.import.modal.table-header.total-translated": "% traduzido",
+  "catalog-translation.import.modal.status-list.error": "Erro"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -51,7 +51,7 @@
   "catalog-translation.import.modal.request-tab": "Traduções",
   "catalog-translation.import.modal.download-button": "Download xlsx modelo",
   "catalog-translation.import.modal.dropzone": "Drop aqui seu XLSX ou ",
-  "catalog-translation.import.modal.model-dropzone-choose-file": "escolha um arquivo",
+  "catalog-translation.import.modal.dropzone-choose-file": "escolha um arquivo",
   "catalog-translation.import.modal.total-entries": "registros",
   "catalog-translation.import.modal.total-warnings": "alertas",
   "catalog-translation.import.modal.total-errors": "erros. Os registros serão ignorados",
@@ -61,5 +61,8 @@
   "catalog-translation.import.modal.table-header.created-at": "Criado em",
   "catalog-translation.import.modal.table-header.progress": "Progresso",
   "catalog-translation.import.modal.table-header.total-translated": "% traduzido",
-  "catalog-translation.import.modal.status-list.error": "Erro"
+  "catalog-translation.import.modal.status-list.error": "Erro",
+  "catalog-translation.import.warning-and-error": "de",
+  "catalog-translation.import.table-header.line": "Linha",
+  "catalog-translation.import.table-header.missing-fields": "Campos vazios"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -43,5 +43,22 @@
   "catalog-translation.export.modal.table-header.requested.at": "Solicitado em",
   "catalog-translation.export.modal.table-header.download": "Download",
   "catalog-translation.export.modal.download-list.error": "Erro ao criar arquivo",
-  "catalog-translation.export.modal.download-list.download-btn": "Download"
+  "catalog-translation.export.modal.download-list.download-btn": "Download",
+  "catalog-translation.import.modal.cancelation": "Cancelar",
+  "catalog-translation.import.modal.confirmation": "Enviar Traduções",
+  "catalog-translation.import.modal.header": "Importar traducciones de productos para {selectedLocale}",
+  "catalog-translation.import.modal.import-tab": "Importar",
+  "catalog-translation.import.modal.request-tab": "Traduções",
+  "catalog-translation.import.modal.download-button": "Download xlsx modelo",
+  "catalog-translation.import.modal.dropzone": "Drop aqui seu XLSX ou ",
+  "catalog-translation.import.modal.model-dropzone-choose-file": "escolha um arquivo",
+  "catalog-translation.import.modal.total-entries": "registros",
+  "catalog-translation.import.modal.total-warnings": "alertas",
+  "catalog-translation.import.modal.total-errors": "erros. Os registros serão ignorados",
+  "catalog-translation.import.modal.error-uploading": "Erro ao fazer upload",
+  "catalog-translation.import.modal.table-header.locale": "Locale",
+  "catalog-translation.import.modal.table-header.translated-by": "Traduzido por",
+  "catalog-translation.import.modal.table-header.created-at": "Criado em",
+  "catalog-translation.import.modal.table-header.progress": "Progresso",
+  "catalog-translation.import.modal.table-header.total-translated": "% traduzido"
 }

--- a/node/package.json
+++ b/node/package.json
@@ -4,7 +4,8 @@
   "main": "index.ts",
   "license": "UNLICENSED",
   "dependencies": {
-    "@vtex/api": "6.44.0"
+    "@vtex/api": "6.44.0",
+    "JSONStream": "^1.3.5"
   },
   "devDependencies": {
     "@vtex/tsconfig": "^0.5.6",

--- a/node/resolvers/product/upload.ts
+++ b/node/resolvers/product/upload.ts
@@ -119,7 +119,7 @@ const uploadProductTranslations = async (
 
   uploadProductAsync({ products, requestId, locale }, { catalogGQL, vbase })
 
-  return true
+  return requestId
 }
 
 const productTranslationsUploadRequests = async (

--- a/node/typings/JSONStream.d.ts
+++ b/node/typings/JSONStream.d.ts
@@ -1,0 +1,1 @@
+declare module 'JSONStream'

--- a/node/typings/product.d.ts
+++ b/node/typings/product.d.ts
@@ -49,3 +49,10 @@ interface UploadRequest {
   error?: boolean
   progress?: number
 }
+
+type UploadFile<T> = Promise<{
+  filename: string
+  mimetype: string
+  enconding: string
+  createReadStream: () => T
+}>

--- a/node/typings/product.d.ts
+++ b/node/typings/product.d.ts
@@ -38,6 +38,7 @@ interface ProductTranslationInput {
   description?: string
   shortDescription?: string
   title?: string
+  linkId?: string
 }
 
 interface UploadRequest {

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -187,6 +187,14 @@
   dependencies:
     tslib "^1.9.3"
 
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
+
 accepts@^1.3.5:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -828,6 +836,11 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonparse@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
+
 keygrip@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
@@ -1277,6 +1290,11 @@ thriftrw@^3.5.0:
     bufrw "^1.3.0"
     error "7.0.2"
     long "^2.4.0"
+
+"through@>=2.2.7 <3":
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 toidentifier@1.0.0:
   version "1.0.0"

--- a/react/components/ImportStatusList.tsx
+++ b/react/components/ImportStatusList.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from 'react-apollo'
 import React, { useEffect, useRef, useState } from 'react'
-import { FormattedDate, FormattedTime } from 'react-intl'
+import { FormattedDate, FormattedMessage, FormattedTime } from 'react-intl'
 import { Progress } from 'vtex.styleguide'
 
 import PRODUCT_UPLOAD_REQUEST_INFO from '../graphql/productUploadRequestInfo.gql'
@@ -65,7 +65,9 @@ const ImportStatusList = ({ requestId }: { requestId: string }) => {
       </td>
       <td>
         {error || shouldHaveFinished ? (
-          <p className="c-danger i f7">Error</p>
+          <p className="c-danger i f7">
+            <FormattedMessage id="catalog-translation.import.modal.status-list.error" />
+          </p>
         ) : (
           <Progress
             type="steps"

--- a/react/components/ImportStatusList.tsx
+++ b/react/components/ImportStatusList.tsx
@@ -1,0 +1,83 @@
+import { useQuery } from 'react-apollo'
+import React, { useEffect, useRef, useState } from 'react'
+import { FormattedDate, FormattedTime } from 'react-intl'
+import { Progress } from 'vtex.styleguide'
+
+import PRODUCT_UPLOAD_REQUEST_INFO from '../graphql/productUploadRequestInfo.gql'
+import { shouldHaveCompleted } from '../utils'
+
+const ImportStatusList = ({ requestId }: { requestId: string }) => {
+  const [shouldHaveFinished, setShouldHaveFinished] = useState(false)
+  const {
+    data,
+    error: errorFetchingInfo,
+    startPolling,
+    stopPolling,
+  } = useQuery<
+    { translationUploadRequestInfo: UploadRequest },
+    { requestId: string }
+  >(PRODUCT_UPLOAD_REQUEST_INFO, {
+    variables: {
+      requestId,
+    },
+  })
+
+  const { translatedBy, createdAt, estimatedTime, locale, error, progress } =
+    data?.translationUploadRequestInfo ?? {}
+
+  const tooLongRef = useRef<any>()
+
+  useEffect(() => {
+    if (progress !== 100 && !error && createdAt && estimatedTime) {
+      if (shouldHaveCompleted(createdAt, estimatedTime)) {
+        stopPolling()
+        setShouldHaveFinished(true)
+        return
+      }
+      startPolling(estimatedTime / 8)
+    }
+    if (progress === 100 || error) {
+      stopPolling()
+      clearTimeout(tooLongRef.current)
+    }
+
+    return () => stopPolling()
+  }, [progress, error, createdAt, estimatedTime, stopPolling, startPolling])
+
+  return !data || errorFetchingInfo ? null : (
+    <tr>
+      <td>
+        <p>{locale}</p>
+      </td>
+      <td>
+        <p>{translatedBy}</p>
+      </td>
+      <td>
+        {createdAt ? (
+          <span>
+            <p>
+              <FormattedTime value={createdAt} />
+              {' - '}
+              <FormattedDate value={createdAt} />
+            </p>
+          </span>
+        ) : null}
+      </td>
+      <td>
+        {error || shouldHaveFinished ? (
+          <p className="c-danger i f7">Error</p>
+        ) : (
+          <Progress
+            type="steps"
+            steps={[progress === 100 ? 'completed' : 'inProgress']}
+          />
+        )}
+      </td>
+      <td>
+        <p>{progress ?? '0'}%</p>
+      </td>
+    </tr>
+  )
+}
+
+export default ImportStatusList

--- a/react/components/ImportStatusList.tsx
+++ b/react/components/ImportStatusList.tsx
@@ -29,7 +29,7 @@ const ImportStatusList = ({ requestId }: { requestId: string }) => {
 
   useEffect(() => {
     if (progress !== 100 && !error && createdAt && estimatedTime) {
-      if (shouldHaveCompleted(createdAt, estimatedTime)) {
+      if (shouldHaveCompleted(createdAt, estimatedTime * 1.5)) {
         stopPolling()
         setShouldHaveFinished(true)
         return

--- a/react/components/ProductTranslation/ProductImportModal.tsx
+++ b/react/components/ProductTranslation/ProductImportModal.tsx
@@ -32,8 +32,8 @@ const ProductImportModal = ({
   const [validtionWarnings, setValidationWarnings] = useState<Message[]>([])
   const [originalFile, setOriginalFile] = useState<Array<{}>>([])
   const [formattedTranslations, setFormattedTranslations] = useState<
-    Array<Record<EntryHeaders<Product>, string>>
-  >([])
+    Blob | undefined
+  >(undefined)
 
   const [tabSelected, setTabSelected] = useState<1 | 2>(1)
   const { selectedLocale } = useLocaleSelector()
@@ -66,7 +66,15 @@ const ProductImportModal = ({
         setValidationWarnings(warnings)
       }
 
-      setFormattedTranslations(translations)
+      const blob = new Blob([JSON.stringify(translations, null, 2)], {
+        type: 'application/json',
+      })
+
+      // const file = new File([blob], 'product_translation', {
+      //   lastModified: 1534584790000,
+      // })
+
+      setFormattedTranslations(blob)
     } catch (e) {
       setErrorParsingFile(e)
     } finally {
@@ -86,7 +94,7 @@ const ProductImportModal = ({
       return
     }
     setOriginalFile([])
-    setFormattedTranslations([])
+    setFormattedTranslations(undefined)
     cleanErrors()
   }
 
@@ -110,7 +118,7 @@ const ProductImportModal = ({
     },
     {
       locale: string
-      products: ProductTranslationInput[]
+      products: Blob
     }
   >(UPLOAD_PRODUCT_TRANSLATION)
 
@@ -119,6 +127,10 @@ const ProductImportModal = ({
   }>(UPLOAD_PRODUCT_REQUESTS)
 
   const handleUploadRequest = async () => {
+    if (!formattedTranslations) {
+      return
+    }
+
     const { data: newRequest } = await startProductUpload({
       variables: {
         locale: selectedLocale,

--- a/react/components/ProductTranslation/ProductImportModal.tsx
+++ b/react/components/ProductTranslation/ProductImportModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { useMutation, useQuery } from 'react-apollo'
 import { ModalDialog, ButtonPlain, Dropzone, Tabs, Tab } from 'vtex.styleguide'
+import { FormattedMessage } from 'react-intl'
 
 import { sanitizeImportJSON, parseXLSToJSON, parseJSONToXLS } from '../../utils'
 import { useLocaleSelector } from '../LocaleSelector'
@@ -152,14 +153,18 @@ const ProductImportModal = ({
     <ModalDialog
       loading={loading}
       cancelation={{
-        label: 'Cancel',
+        label: (
+          <FormattedMessage id="catalog-translation.import.modal.cancelation" />
+        ),
         onClick: () => {
           handleOpenImport(false)
           cleanErrors()
         },
       }}
       confirmation={{
-        label: 'Send Translations',
+        label: (
+          <FormattedMessage id="catalog-translation.import.modal.confirmation" />
+        ),
         onClick: () => {
           if (errorParsingFile) {
             return
@@ -173,11 +178,20 @@ const ProductImportModal = ({
         cleanErrors()
       }}
     >
-      <h3>{`Import Product Translations for ${selectedLocale}`}</h3>
+      <h3>
+        <FormattedMessage
+          id="catalog-translation.import.modal.header"
+          values={{
+            selectedLocale,
+          }}
+        />
+      </h3>
       <div>
         <Tabs>
           <Tab
-            label="Import"
+            label={
+              <FormattedMessage id="catalog-translation.import.modal.import-tab" />
+            }
             active={tabSelected === 1}
             onClick={() => {
               setTabSelected(1)
@@ -187,7 +201,7 @@ const ProductImportModal = ({
             <div>
               <div className="mv4">
                 <ButtonPlain onClick={createModel}>
-                  Download xlsx model
+                  <FormattedMessage id="catalog-translation.import.modal.model-download-button" />
                 </ButtonPlain>
               </div>
               <div>
@@ -197,9 +211,11 @@ const ProductImportModal = ({
                   onFileReset={handleReset}
                 >
                   <div className="pt7">
-                    <span className="f4">Drop here your XLSX or </span>
+                    <span className="f4">
+                      <FormattedMessage id="catalog-translation.import.modal.dropzone" />
+                    </span>
                     <span className="f4 c-link" style={{ cursor: 'pointer' }}>
-                      choose a file
+                      <FormattedMessage id="catalog-translation.import.modal.dropzone-choose-file" />
                     </span>
                   </div>
                 </Dropzone>
@@ -210,12 +226,16 @@ const ProductImportModal = ({
             </div>
             <ul>
               {originalFile.length ? (
-                <li>{originalFile?.length} total entries</li>
+                <li>
+                  {originalFile?.length}{' '}
+                  <FormattedMessage id="catalog-translation.import.modal.total-entries" />
+                </li>
               ) : null}
               {validtionWarnings.length ? (
                 <li>
                   <ButtonPlain onClick={() => setWarningModal(true)}>
-                    {validtionWarnings.length} warnings.
+                    {validtionWarnings.length}{' '}
+                    <FormattedMessage id="catalog-translation.import.modal.total-warnings" />
                   </ButtonPlain>
                 </li>
               ) : null}
@@ -225,20 +245,22 @@ const ProductImportModal = ({
                     variation="danger"
                     onClick={() => setErrorModal(true)}
                   >
-                    {validtionErrors.length} errors. The entries will be
-                    ignored.
+                    {validtionErrors.length}{' '}
+                    <FormattedMessage id="catalog-translation.import.modal.total-errors" />
                   </ButtonPlain>
                 </li>
               ) : null}
             </ul>
             {uploadError ? (
               <p className="absolute c-danger i-s bottom-0-m right-0-m mr8">
-                Error uploading product translations
+                <FormattedMessage id="catalog-translation.import.modal.error-uploading" />
               </p>
             ) : null}
           </Tab>
           <Tab
-            label="Requests"
+            label={
+              <FormattedMessage id="catalog-translation.import.modal.request-tab" />
+            }
             active={tabSelected === 2}
             onClick={() => {
               setTabSelected(2)
@@ -248,11 +270,21 @@ const ProductImportModal = ({
             <table className="w-100 mt7 tc">
               <thead>
                 <tr>
-                  <th>Locale</th>
-                  <th>Translated by</th>
-                  <th>Created at</th>
-                  <th>Progress</th>
-                  <th>% Translated</th>
+                  <th>
+                    <FormattedMessage id="catalog-translation.import.modal.table-header.locale" />
+                  </th>
+                  <th>
+                    <FormattedMessage id="catalog-translation.import.modal.table-header.translated-by" />
+                  </th>
+                  <th>
+                    <FormattedMessage id="catalog-translation.import.modal.table-header.created-at" />
+                  </th>
+                  <th>
+                    <FormattedMessage id="catalog-translation.import.modal.table-header.progress" />
+                  </th>
+                  <th>
+                    <FormattedMessage id="catalog-translation.import.modal.table-header.total-translated" />
+                  </th>
                 </tr>
               </thead>
               <tbody>

--- a/react/components/ProductTranslation/ProductImportModal.tsx
+++ b/react/components/ProductTranslation/ProductImportModal.tsx
@@ -70,10 +70,6 @@ const ProductImportModal = ({
         type: 'application/json',
       })
 
-      // const file = new File([blob], 'product_translation', {
-      //   lastModified: 1534584790000,
-      // })
-
       setFormattedTranslations(blob)
     } catch (e) {
       setErrorParsingFile(e)
@@ -184,6 +180,7 @@ const ProductImportModal = ({
             active={tabSelected === 1}
             onClick={() => {
               setTabSelected(1)
+              handleReset()
             }}
           >
             <div>
@@ -242,7 +239,10 @@ const ProductImportModal = ({
           <Tab
             label="Requests"
             active={tabSelected === 2}
-            onClick={() => setTabSelected(2)}
+            onClick={() => {
+              setTabSelected(2)
+              handleReset()
+            }}
           >
             <table className="w-100 mt7 tc">
               <thead>

--- a/react/components/ProductTranslation/ProductImportModal.tsx
+++ b/react/components/ProductTranslation/ProductImportModal.tsx
@@ -15,6 +15,7 @@ const categoryHeaders: Array<keyof Product> = [
   'title',
   'description',
   'shortDescription',
+  'linkId',
 ]
 
 const PRODUCT_DATA = 'product_data'

--- a/react/components/ProductTranslation/ProductImportModal.tsx
+++ b/react/components/ProductTranslation/ProductImportModal.tsx
@@ -201,7 +201,7 @@ const ProductImportModal = ({
             <div>
               <div className="mv4">
                 <ButtonPlain onClick={createModel}>
-                  <FormattedMessage id="catalog-translation.import.modal.model-download-button" />
+                  <FormattedMessage id="catalog-translation.import.modal.download-button" />
                 </ButtonPlain>
               </div>
               <div>

--- a/react/components/ProductTranslation/ProductImportModal.tsx
+++ b/react/components/ProductTranslation/ProductImportModal.tsx
@@ -2,15 +2,15 @@ import React, { useState } from 'react'
 import { ModalDialog, ButtonPlain, Dropzone, Tabs, Tab } from 'vtex.styleguide'
 
 import { sanitizeImportJSON, parseXLSToJSON, parseJSONToXLS } from '../../utils'
+import { useLocaleSelector } from '../LocaleSelector'
 import WarningAndErrorsImportModal from '../WarningAndErrorsImportModal'
 
-const categoryHeaders: Array<keyof Product | 'locale'> = [
+const categoryHeaders: Array<keyof Product> = [
   'id',
   'name',
   'title',
   'description',
   'shortDescription',
-  'locale',
 ]
 
 const PRODUCT_DATA = 'product_data'
@@ -31,6 +31,7 @@ const ProductImportModal = ({
   >([])
 
   const [tabSelected, setTabSelected] = useState<1 | 2>(1)
+  const { selectedLocale } = useLocaleSelector()
 
   const handleFile = async (files: FileList) => {
     if (loading) {
@@ -49,7 +50,7 @@ const ProductImportModal = ({
       const [translations, { errors, warnings }] = sanitizeImportJSON<Product>({
         data: fileParsed,
         entryHeaders: categoryHeaders,
-        requiredHeaders: ['id', 'locale'],
+        requiredHeaders: ['id'],
       })
 
       if (errors.length) {
@@ -124,7 +125,7 @@ const ProductImportModal = ({
         cleanErrors()
       }}
     >
-      <h3>Import Category Translations</h3>
+      <h3>{`Import Category Translations for ${selectedLocale}`}</h3>
       <div>
         <Tabs>
           <Tab

--- a/react/components/ProductTranslation/ProductImportModal.tsx
+++ b/react/components/ProductTranslation/ProductImportModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { ModalDialog, ButtonPlain, Dropzone } from 'vtex.styleguide'
+import { ModalDialog, ButtonPlain, Dropzone, Tabs, Tab } from 'vtex.styleguide'
 
 import { sanitizeImportJSON, parseXLSToJSON, parseJSONToXLS } from '../../utils'
 import WarningAndErrorsImportModal from '../WarningAndErrorsImportModal'
@@ -29,6 +29,8 @@ const ProductImportModal = ({
   const [translationsAdj, setTranslationsAdj] = useState<
     Array<Record<EntryHeaders<Product>, string>>
   >([])
+
+  const [tabSelected, setTabSelected] = useState<1 | 2>(1)
 
   const handleFile = async (files: FileList) => {
     if (loading) {
@@ -122,46 +124,73 @@ const ProductImportModal = ({
         cleanErrors()
       }}
     >
+      <h3>Import Category Translations</h3>
       <div>
-        <h3>Import Category Translations</h3>
-        <ButtonPlain onClick={createModel}>Download xlsx model</ButtonPlain>
-        <div className="mt2">
-          <Dropzone
-            accept=".xlsx"
-            onDropAccepted={handleFile}
-            onFileReset={handleReset}
+        <Tabs>
+          <Tab
+            label="Import"
+            active={tabSelected === 1}
+            onClick={() => {
+              setTabSelected(1)
+            }}
           >
-            <div className="pt7">
-              <span className="f4">Drop here your XLSX or </span>
-              <span className="f4 c-link" style={{ cursor: 'pointer' }}>
-                choose a file
-              </span>
+            <div>
+              <div className="mv4">
+                <ButtonPlain onClick={createModel}>
+                  Download xlsx model
+                </ButtonPlain>
+              </div>
+              <div>
+                <Dropzone
+                  accept=".xlsx"
+                  onDropAccepted={handleFile}
+                  onFileReset={handleReset}
+                >
+                  <div className="pt7">
+                    <span className="f4">Drop here your XLSX or </span>
+                    <span className="f4 c-link" style={{ cursor: 'pointer' }}>
+                      choose a file
+                    </span>
+                  </div>
+                </Dropzone>
+              </div>
+              {errorParsingFile ? (
+                <p className="c-danger i f7">{errorParsingFile}</p>
+              ) : null}
             </div>
-          </Dropzone>
-        </div>
-        {errorParsingFile ? (
-          <p className="c-danger i f7">{errorParsingFile}</p>
-        ) : null}
+            <ul>
+              {originalFile.length ? (
+                <li>{originalFile?.length} total entries</li>
+              ) : null}
+              {validtionWarnings.length ? (
+                <li>
+                  <ButtonPlain onClick={() => setWarningModal(true)}>
+                    {validtionWarnings.length} warnings.
+                  </ButtonPlain>
+                </li>
+              ) : null}
+              {validtionErrors.length ? (
+                <li>
+                  <ButtonPlain
+                    variation="danger"
+                    onClick={() => setErrorModal(true)}
+                  >
+                    {validtionErrors.length} errors. The entries will be
+                    ignored.
+                  </ButtonPlain>
+                </li>
+              ) : null}
+            </ul>
+          </Tab>
+          <Tab
+            label="Requests"
+            active={tabSelected === 2}
+            onClick={() => setTabSelected(2)}
+          >
+            <div>Request list</div>
+          </Tab>
+        </Tabs>
       </div>
-      <ul>
-        {originalFile.length ? (
-          <li>{originalFile?.length} total entries</li>
-        ) : null}
-        {validtionWarnings.length ? (
-          <li>
-            <ButtonPlain onClick={() => setWarningModal(true)}>
-              {validtionWarnings.length} warnings.
-            </ButtonPlain>
-          </li>
-        ) : null}
-        {validtionErrors.length ? (
-          <li>
-            <ButtonPlain variation="danger" onClick={() => setErrorModal(true)}>
-              {validtionErrors.length} errors. The entries will be ignored.
-            </ButtonPlain>
-          </li>
-        ) : null}
-      </ul>
       <WarningAndErrorsImportModal
         isOpen={warningModal}
         modalName="Warning Modal"

--- a/react/components/WarningAndErrorsImportModal.tsx
+++ b/react/components/WarningAndErrorsImportModal.tsx
@@ -1,20 +1,31 @@
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import React, {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { FormattedMessage, IntlShape, useIntl } from 'react-intl'
 import { Modal, Pagination, Table } from 'vtex.styleguide'
 
-const tableSchema = {
+const tableSchemaGenerator = (intl: IntlShape) => ({
   properties: {
     line: {
-      title: 'Line',
+      title: intl.formatMessage({
+        id: 'catalog-translation.import.table-header.line',
+      }),
     },
     missingFields: {
-      title: 'Missing Fields',
+      title: intl.formatMessage({
+        id: 'catalog-translation.import.table-header.missing-fields',
+      }),
       // eslint-disable-next-line react/display-name
       cellRenderer: ({ cellData }: { cellData: string[] }) => (
         <p>{cellData.join(', ')}</p>
       ),
     },
   },
-}
+})
 
 interface ComponentProps {
   modalName: string
@@ -35,6 +46,7 @@ const WarningAndErrorsImportModal = ({
   const [slicedData, setSlicedData] = useState<Message[]>([])
   const [from, setFrom] = useState(ITEM_FROM)
   const [to, setTo] = useState(ITEM_FROM + STEPS)
+  const intl = useIntl()
 
   useEffect(() => {
     setSlicedData(data.slice(ITEM_FROM, ITEM_FROM + STEPS))
@@ -60,12 +72,16 @@ const WarningAndErrorsImportModal = ({
     setSlicedData(selectedData)
   }
 
+  const tableSchema = useMemo(() => tableSchemaGenerator(intl), [intl])
+
   return (
     <Modal isOpen={isOpen} onClose={() => handleClose(false)}>
       <Pagination
         currentItemFrom={from + 1}
         currentItemTo={to}
-        textOf="of"
+        textOf={
+          <FormattedMessage id="catalog-translation.import.warning-and-error" />
+        }
         totalItems={data.length}
         onNextClick={handleNext}
         onPrevClick={handlePrev}

--- a/react/graphql/productUploadRequestInfo.gql
+++ b/react/graphql/productUploadRequestInfo.gql
@@ -1,0 +1,12 @@
+query translationUploadRequestInfo($requestId: String!) {
+  translationUploadRequestInfo(requestId: $requestId)
+    @context(provider: "vtex.admin-catalog-translation") {
+    requestId
+    translatedBy
+    createdAt
+    estimatedTime
+    error
+    progress
+    locale
+  }
+}

--- a/react/graphql/productUploadRequests.gql
+++ b/react/graphql/productUploadRequests.gql
@@ -1,0 +1,4 @@
+query productTranslationsUploadRequests {
+  productTranslationsUploadRequests
+    @context(provider: "vtex.admin-catalog-translation")
+}

--- a/react/graphql/uploadProductTranslation.gql
+++ b/react/graphql/uploadProductTranslation.gql
@@ -1,0 +1,7 @@
+mutation uploadProductTranslations(
+  $locale: String!
+  $products: [ProductTranslationUpload]!
+) {
+  uploadProductTranslations(locale: $locale, products: $products)
+    @context(provider: "vtex.admin-catalog-translation")
+}

--- a/react/graphql/uploadProductTranslation.gql
+++ b/react/graphql/uploadProductTranslation.gql
@@ -1,7 +1,4 @@
-mutation uploadProductTranslations(
-  $locale: String!
-  $products: [ProductTranslationUpload]!
-) {
+mutation uploadProductTranslations($locale: String!, $products: Upload!) {
   uploadProductTranslations(locale: $locale, products: $products)
     @context(provider: "vtex.admin-catalog-translation")
 }

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -120,6 +120,7 @@ interface ProductTranslationInput {
   description?: string
   shortDescription?: string
   title?: string
+  linkId?: string
 }
 
 interface UploadRequest {

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -121,3 +121,13 @@ interface ProductTranslationInput {
   shortDescription?: string
   title?: string
 }
+
+interface UploadRequest {
+  requestId: string
+  translatedBy: string
+  createdAt: string
+  estimatedTime: number
+  locale: string
+  error?: boolean
+  progress?: number
+}

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -113,3 +113,11 @@ interface SkuTranslationRequests {
 interface SkuTranslationDownload {
   downloadSKUTranslation: SKU[]
 }
+
+interface ProductTranslationInput {
+  id: string
+  name?: string
+  description?: string
+  shortDescription?: string
+  title?: string
+}


### PR DESCRIPTION
**What problem is this solving?**

<!--- What is the motivation and context for this change? -->
This PR connects back end (PR #14) and front end (PR #13) features to allow user to upload product translations.

It also adds:

1. A UI where the user can see the status of the last requests for translations;

The process starts on `react/components/ProductTranslation/ProductImportModal.tsx`, with a query `UPLOAD_PRODUCT_REQUESTS` to get all the requests made to upload translations. The id of each request is passed to `react/components/ImportStatusList.tsx`, which will fetch the request details and manage translations in progress.

2. Allow user to send big several entries at once converting them to a binary file to send it to back end;

Instead of sending a JSON as argument to `react/graphql/uploadProductTranslation.gql` mutation, it converts the parsed file into a binary with the Blob constructor.

In the back end, we convert it on `node/resolvers/product/upload.ts` back to JSON, using a external library.

3. Add l11n to upload components.

**How should this be manually tested?**

[This workspace](https://uploadprodtranslation--powerplanet.myvtex.com/admin/catalog-translation/product) has the branch linked on it. 
Select a locale, than input a file with the translations. 

**Screenshots or example usage:**
![recording(2)](https://user-images.githubusercontent.com/38737958/129887073-2529cd72-cdbb-4351-b560-9a063fbd49b3.gif)
