### PR TITLE
Use defaultLocale as xVtexTenant

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -4,7 +4,7 @@
   "main": "index.ts",
   "license": "UNLICENSED",
   "dependencies": {
-    "@vtex/api": "6.44.0"
+    "@vtex/api": "6.45.4"
   },
   "devDependencies": {
     "@vtex/tsconfig": "^0.5.6",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -122,10 +122,10 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@vtex/api@6.44.0":
-  version "6.44.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.44.0.tgz#8dc2a27c37635278117310bcc5cd16203c0a5849"
-  integrity sha512-7nPIwzQz55Mu0E1BOoW1noObZet9J34iKmeAJU3TRL7iiGmPZB0McSjC6KgDHkfqYgim2JGrnCsa1978ffbwKQ==
+"@vtex/api@6.45.4":
+  version "6.45.4"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.4.tgz#58be7497c0c0f91a388fabd42149e48cb95e271d"
+  integrity sha512-DVAJr5BkSjXupjn2h5Z1In8C3Li9kZwCXPwRQbpIgyS7s9dN2ZEFQc6nQlJm6ZoDCoyYBg62LgD7Kurvz9jc3w==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/react/components/LocaleSelector.tsx
+++ b/react/components/LocaleSelector.tsx
@@ -37,10 +37,11 @@ const BindingProvider: FC = ({ children }) => {
     // eslint-disable-next-line vtex/prefer-early-return
     if (bindingData) {
       const fetchedLocales = bindingData.tenantInfo.bindings
+      const { defaultLocale } = bindingData.tenantInfo
       const filteredLocales = filterLocales(fetchedLocales)
       setBindings(filteredLocales)
-      setSelectedLocale(filteredLocales[0].defaultLocale)
-      setXVtexTenant(filteredLocales[0].defaultLocale)
+      setSelectedLocale(defaultLocale)
+      setXVtexTenant(defaultLocale)
     }
   }, [bindingData])
 

--- a/react/components/LocaleSelector.tsx
+++ b/react/components/LocaleSelector.tsx
@@ -36,8 +36,7 @@ const BindingProvider: FC = ({ children }) => {
   useEffect(() => {
     // eslint-disable-next-line vtex/prefer-early-return
     if (bindingData) {
-      const fetchedLocales = bindingData.tenantInfo.bindings
-      const { defaultLocale } = bindingData.tenantInfo
+      const { defaultLocale, bindings: fetchedLocales } = bindingData.tenantInfo
       const filteredLocales = filterLocales(fetchedLocales, defaultLocale)
       setBindings(filteredLocales)
       setSelectedLocale(defaultLocale)

--- a/react/components/LocaleSelector.tsx
+++ b/react/components/LocaleSelector.tsx
@@ -38,7 +38,7 @@ const BindingProvider: FC = ({ children }) => {
     if (bindingData) {
       const fetchedLocales = bindingData.tenantInfo.bindings
       const { defaultLocale } = bindingData.tenantInfo
-      const filteredLocales = filterLocales(fetchedLocales)
+      const filteredLocales = filterLocales(fetchedLocales, defaultLocale)
       setBindings(filteredLocales)
       setSelectedLocale(defaultLocale)
       setXVtexTenant(defaultLocale)

--- a/react/graphql/accountLocales.gql
+++ b/react/graphql/accountLocales.gql
@@ -1,5 +1,6 @@
 query accountLocales {
   tenantInfo @context(provider: "vtex.tenant-graphql") {
+    defaultLocale
     bindings {
       id
       defaultLocale

--- a/react/typings/bindings.d.ts
+++ b/react/typings/bindings.d.ts
@@ -6,6 +6,7 @@ interface Binding {
 
 interface BindingsData {
   tenantInfo: {
+    defaultLocale: string
     bindings: Binding[]
   }
 }

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -2,13 +2,34 @@ import { Translation } from 'vtex.messages'
 import XLSX from 'xlsx'
 
 /**
+ * Keep the xVtexTenant in the top of the dropdown button
+ */
+const sortBindings = (bindings: Binding[], xVtexTenant: string): Binding[] => {
+  const xVtexTenantBinding = []
+  const otherBindings = []
+
+  for (const binding of bindings) {
+    if (binding.defaultLocale === xVtexTenant) {
+      xVtexTenantBinding.push(binding)
+    } else {
+      otherBindings.push(binding)
+    }
+  }
+
+  return [...xVtexTenantBinding, ...otherBindings]
+}
+
+/**
  * Returns all the unique binding locales, excluding the first one provided by the api (admin)
  *
  * @param {array} Array received from api graphql
  * @return {array} Array with only unique locales and without the admin binding.
  */
 
-export const filterLocales = (bindings: Binding[]): Binding[] => {
+export const filterLocales = (
+  bindings: Binding[],
+  xVtexTenant: string
+): Binding[] => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [admin, ...otherBindings] = bindings
   const uniqueBindings: { [id: string]: boolean } = {}
@@ -35,7 +56,7 @@ export const filterLocales = (bindings: Binding[]): Binding[] => {
     }
   }
 
-  return filteredBindings
+  return sortBindings(filteredBindings, xVtexTenant)
 }
 
 /**


### PR DESCRIPTION
**What problem is this solving?**

<!--- What is the motivation and context for this change? -->
The current implementation relies on the idea that the second object returned from tenant API is the `xVtexTenant`. However, this has proved to not be always true. For [floriaro store](https://portal.vtexcommercestable.com.br/api/tenant/tenants?q=floriaro) the default language of the second object is `en-GB`, while the store main language is `ro-RO`. It prevents the entries to be translated.

To fix that, we use the `defaultLocale` from the root object returned from tenant.

**How should this be manually tested?**

This new branch is linked [here](https://catalogtransldefaultlocale--floriaro.myvtex.com/admin/catalog-translation/category). Before the implementation, the user was getting an error when trying to translate an entry. It should work fine now.


