### PR TITLE
Add/sepecification values translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Add
+- Translations to specifications values feature
+
 ## [2.3.1] - 2024-08-05
 
 ### Fixed

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1223,7 +1223,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/SpecificationsTranslation.tsx
+++ b/react/SpecificationsTranslation.tsx
@@ -1,20 +1,46 @@
-import React, { FC } from 'react'
+import React, { FC, useState } from 'react'
 import { FormattedMessage } from 'react-intl'
+import { Tabs, Tab, Layout, PageHeader } from 'vtex.styleguide'
 
 import CatalogTranslationWrapper from './components/CatalogTranslationWrapper'
 import SpecificationsTranslation from './components/SpecificationsTranslation/SpecificationsTranslation'
+import SpecificationsTranslationValues from './components/SpecificationsTranslation/SpecificationsTranslationValues'
 
 const SpecificationsTranslationWrapped: FC = () => {
+  const [currentTab, setCurrentTab] = useState<number>(1)
   return (
-    <CatalogTranslationWrapper
-      titleComponent={
-        <FormattedMessage id="admin/catalog-translation.specifications.header" />
-      }
-      hasExport
-      hasImport
-    >
-      <SpecificationsTranslation />
-    </CatalogTranslationWrapper>
+    <Layout className="pd10">
+      <Tabs>
+        <Tab
+          label="Specifications"
+          active={currentTab === 1}
+          onClick={() => setCurrentTab(1)}>
+            <CatalogTranslationWrapper
+              titleComponent={
+                <FormattedMessage id="admin/catalog-translation.specifications.header" />
+              }
+              hasExport
+              hasImport
+            >
+                  <SpecificationsTranslation />
+            </CatalogTranslationWrapper>
+        </Tab>
+        <Tab
+          label="Specification Values"
+          active={currentTab === 2}
+          onClick={() => setCurrentTab(2)}>
+            <CatalogTranslationWrapper
+              titleComponent={
+                <FormattedMessage id="admin/catalog-translation.specifications.header" />
+              }
+              hasExport={false}
+              hasImport={false}
+            >
+              <SpecificationsTranslationValues />
+            </CatalogTranslationWrapper>
+        </Tab>
+      </Tabs>
+    </Layout>
   )
 }
 

--- a/react/components/SpecificationsTranslation/SpecificationsForm.tsx
+++ b/react/components/SpecificationsTranslation/SpecificationsForm.tsx
@@ -3,7 +3,7 @@ import { Input } from 'vtex.styleguide'
 import { useMutation } from 'react-apollo'
 
 import { useLocaleSelector } from '../LocaleSelector'
-import translateSpecificationMutation from './graphql/translateSpecification.gql'
+import translateFieldValues from './graphql/translateSpecification.gql'
 import { useAlert } from '../../providers/AlertProvider'
 import useFormTranslation from '../../hooks/useFormTranslation'
 import ActionButtons from '../ActionButtons'
@@ -35,7 +35,7 @@ const SpecificationsForm: FC<SpecificationsFormProps> = ({
   const [translateSpecification, { loading }] = useMutation<
     { translateField: boolean },
     { args: Field; locale: string }
-  >(translateSpecificationMutation)
+  >(translateFieldValues)
 
   const { openAlert } = useAlert()
   const handleSubmit = async (e: SyntheticEvent) => {

--- a/react/components/SpecificationsTranslation/SpecificationsTranslationValues.tsx
+++ b/react/components/SpecificationsTranslation/SpecificationsTranslationValues.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useEffect, useState } from 'react'
+import React, { SyntheticEvent } from 'react'
 import { InputSearch, PageBlock, Spinner, PageHeader } from 'vtex.styleguide'
 import { useLazyQuery } from 'react-apollo'
 
@@ -30,7 +30,6 @@ const SpecificationsTranslationValues = ({
     handleCleanSearch,
     errorMessage,
   } = useCatalogQuery<FieldsData, { fieldId: number }>(getSpecificationById)
-  const [specificationValues, setSpecificationValues] = useState<Specification[]>()
   const { selectedLocale, xVtexTenant } = useLocaleSelector()
 
   const [getData, { loading, data }] = useLazyQuery(GetSpecificationValues,{
@@ -60,14 +59,6 @@ const SpecificationsTranslationValues = ({
     })
   }
 
-  useEffect(() => {
-    if (!data) {
-      return
-    }
-    setSpecificationValues(data.fieldValues)
-    
-  }, [data])
-
   const { fieldId, ...specificationInfo } = entryInfo?.field || ({} as Field)
 
   return (
@@ -84,7 +75,7 @@ const SpecificationsTranslationValues = ({
             onClear={handleCleanSearch}
           />
         </div>
-        {specificationValues ? (
+        {data?.fieldValues && !loading ? (
           <PageBlock
           variation="full"
           title={`Specification info- ${selectedLocale}`}
@@ -101,7 +92,7 @@ const SpecificationsTranslationValues = ({
           ) : (
               <SpecificationsValuesForm
                 specificationInfo={specificationInfo}
-                specificationValues={specificationValues}
+                specificationValues={data?.fieldValues}
                 specificationId={entryId}
               />
             )}

--- a/react/components/SpecificationsTranslation/SpecificationsTranslationValues.tsx
+++ b/react/components/SpecificationsTranslation/SpecificationsTranslationValues.tsx
@@ -1,0 +1,114 @@
+import React, { SyntheticEvent, useEffect, useState } from 'react'
+import { InputSearch, PageBlock, Spinner, PageHeader } from 'vtex.styleguide'
+import { useLazyQuery } from 'react-apollo'
+
+import useCatalogQuery from '../../hooks/useCatalogQuery'
+import { useLocaleSelector } from '../LocaleSelector'
+import getSpecificationById from './graphql/getSpecification.gql'
+import GetSpecificationValues from './graphql/getSpecificationValues.gql'
+import ErrorHandler from '../ErrorHandler'
+import SpecificationsValuesForm from './SpecificationsValuesForm'
+import SpecificationExportModal from './SpecificationsExportModal'
+import SpecificationImportModal from './SpecificationsImportModal'
+
+interface Specification {
+  value: string;
+  fieldValueId: string;
+  isActive: boolean;
+}
+
+const SpecificationsTranslationValues = ({
+  isExportOpen = false,
+  handleOpenExport = () => {},
+  isImportOpen = false,
+  handleOpenImport = () => {},
+}: ComponentProps) => {
+  const {
+    entryInfo,
+    entryId,
+    handleEntryIdInput,
+    handleCleanSearch,
+    errorMessage,
+  } = useCatalogQuery<FieldsData, { fieldId: number }>(getSpecificationById)
+  const [specificationValues, setSpecificationValues] = useState<Specification[]>()
+  const { selectedLocale } = useLocaleSelector()
+
+  const [getData, { loading, data }] = useLazyQuery(GetSpecificationValues)
+  console.log("dataaaaaa", data)
+
+  const handleSubmitSpecification = (e: SyntheticEvent) => {
+    console.log("entry", entryId)
+    e.preventDefault()
+    if (!entryId) {
+      return
+    }
+
+    getData({
+      variables: {
+        fieldId: entryId
+      },
+    })
+  }
+
+  useEffect(() => {
+    if (!data) {
+      return
+    }
+    setSpecificationValues(data.fieldValues)
+    
+  }, [data])
+
+  const { fieldId, ...specificationInfo } = entryInfo?.field || ({} as Field)
+
+  return (
+    <>
+      <main>
+        <div style={{ maxWidth: '340px' }} className="mv7">
+          <InputSearch
+            value={entryId}
+            placeHolder="Search Specification..."
+            label="Specification ID"
+            size="regular"
+            onChange={handleEntryIdInput}
+            onSubmit={handleSubmitSpecification}
+            onClear={handleCleanSearch}
+          />
+        </div>
+        {specificationValues ? (
+          <PageBlock
+          variation="full"
+          title={`Specification info- ${selectedLocale}`}
+        >
+          <ul>
+          {errorMessage ? (
+            <ErrorHandler
+              errorMessage={errorMessage}
+              entryId={entryId}
+              entry="Specification"
+            />
+          ) : loading ? (
+            <Spinner />
+          ) : (
+              <SpecificationsValuesForm
+                specificationInfo={specificationInfo}
+                specificationValues={specificationValues}
+                specificationId={entryId}
+              />
+            )}
+          </ul>
+        </PageBlock>
+        ) : null}
+      </main>
+      <SpecificationExportModal
+        isExportOpen={isExportOpen}
+        handleOpenExport={handleOpenExport}
+      />
+      <SpecificationImportModal
+        isImportOpen={isImportOpen}
+        handleOpenImport={handleOpenImport}
+      />
+    </>
+  )
+}
+
+export default SpecificationsTranslationValues

--- a/react/components/SpecificationsTranslation/SpecificationsTranslationValues.tsx
+++ b/react/components/SpecificationsTranslation/SpecificationsTranslationValues.tsx
@@ -31,13 +31,23 @@ const SpecificationsTranslationValues = ({
     errorMessage,
   } = useCatalogQuery<FieldsData, { fieldId: number }>(getSpecificationById)
   const [specificationValues, setSpecificationValues] = useState<Specification[]>()
-  const { selectedLocale } = useLocaleSelector()
+  const { selectedLocale, xVtexTenant } = useLocaleSelector()
 
-  const [getData, { loading, data }] = useLazyQuery(GetSpecificationValues)
-  console.log("dataaaaaa", data)
+  const [getData, { loading, data }] = useLazyQuery(GetSpecificationValues,{
+    context: {
+      headers: {
+        'x-vtex-tenant': `${xVtexTenant}`,
+        'x-vtex-locale': `${selectedLocale}`,
+      },
+    },
+    fetchPolicy: 'no-cache',
+    notifyOnNetworkStatusChange: true,
+    onError: (e) => {
+      console.log("Error context")
+    },
+  })
 
   const handleSubmitSpecification = (e: SyntheticEvent) => {
-    console.log("entry", entryId)
     e.preventDefault()
     if (!entryId) {
       return

--- a/react/components/SpecificationsTranslation/SpecificationsValuesForm.tsx
+++ b/react/components/SpecificationsTranslation/SpecificationsValuesForm.tsx
@@ -1,0 +1,137 @@
+import React, { FC, SyntheticEvent, useEffect, useState, FormEvent } from 'react'
+import { Input, Button } from 'vtex.styleguide'
+import { useMutation } from 'react-apollo'
+import { FormattedMessage } from 'react-intl'
+
+import { useLocaleSelector } from '../LocaleSelector'
+import translateSpecificationValuesMutation from './graphql/translateSpecificationValues.gql'
+import { useAlert } from '../../providers/AlertProvider'
+
+interface SpecificationsFormProps {
+  specificationInfo: FieldInputTranslation
+  specificationId: string
+  specificationValues: Specification[]
+}
+
+interface Specification {
+  value: string;
+  fieldValueId: string;
+  isActive: boolean;
+}
+
+interface SpecificationValue {
+  id: string;
+  name: string;
+}
+
+const SpecificationsValuesForm: FC<SpecificationsFormProps> = ({
+  specificationValues,
+  specificationId
+}) => {
+  const { selectedLocale } = useLocaleSelector()
+  const [fieldValuesNames, setFieldValuesNames] = useState<SpecificationValue[]>()
+  const [changed, setChanged] = useState<boolean>(false)
+  const [canEdit, setCanEdit] = useState<boolean>(false)
+  const [translateSpecificationValues, {loading}] = useMutation(translateSpecificationValuesMutation);
+  const { openAlert } = useAlert()
+
+  useEffect(() => {
+    let values: SpecificationValue[] = []
+    specificationValues.map(specification => {
+      if(specification.isActive) {
+        values.push({
+          id: specification.fieldValueId,
+          name: specification.value
+        })
+      }
+    })
+    setFieldValuesNames(values)
+  }, [])
+
+  const handleInputChange = (itemId: any , index: number) => (e: FormEvent<HTMLInputElement>) => {
+    const { name: fieldName, value } = e.currentTarget
+  
+    const newFieldValuesNames = fieldValuesNames?.map(el => {
+      if (el.id === itemId) {
+        return {...el, name: value};
+      }
+      return el;
+    });
+    setFieldValuesNames(newFieldValuesNames)
+    setChanged(true)
+  }
+
+  const handleToggleEdit = () => {
+    setCanEdit(!canEdit)
+    setChanged(!changed)
+  }
+
+  const handleSubmit = async (e: SyntheticEvent) => {
+    e.preventDefault()
+    try {
+      const { data, errors } = await translateSpecificationValues({
+        variables: {
+          locale: selectedLocale,
+          args: {
+            fieldId: specificationId,
+            fieldValuesNames: fieldValuesNames
+          }
+        },
+      })
+
+      if(data.translateFieldValues) {
+        openAlert('success', 'Specifications Values')
+        setCanEdit(!canEdit)
+      } 
+      if (errors?.length) {
+        throw new TypeError('Error translation Specifications')
+      }
+    } catch (err) {
+      openAlert('error', 'Specifications')
+    }
+  }
+ 
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit}>
+        <div className="mb5">
+          {fieldValuesNames ? fieldValuesNames.map((item: SpecificationValue, index) => {
+            return (
+              <Input
+                key={item.id}
+                label="Name"
+                value={item.name}
+                name="name"
+                disabled={!canEdit}
+                onChange={handleInputChange(item.id, index)}
+              />
+            )
+          }): null}
+        </div>
+        <div>
+          <span className="mr5">
+            <Button type="button" variation="secondary" onClick={handleToggleEdit}>
+              {canEdit ? (
+                <FormattedMessage id="admin/catalog-translation.action-buttons.cancel" />
+              ) : (
+                <FormattedMessage id="admin/catalog-translation.action-buttons.edit" />
+              )}
+            </Button>
+          </span>
+          <span>
+            <Button
+              type="submit"
+              variation="primary"
+              disabled={!changed}
+              isLoading={loading}
+            >
+              <FormattedMessage id="admin/catalog-translation.action-buttons.save" />
+            </Button>
+          </span>
+        </div>
+      </form>
+    </div>
+  )
+}
+export default SpecificationsValuesForm

--- a/react/components/SpecificationsTranslation/graphql/getSpecificationValues.gql
+++ b/react/components/SpecificationsTranslation/graphql/getSpecificationValues.gql
@@ -1,0 +1,8 @@
+query GetSpecificationValues($fieldId: ID!) {
+  fieldValues(fieldId: $fieldId) @context(provider: "vtex.catalog-graphql") {
+    fieldId
+    fieldValueId
+    isActive
+    value
+  }
+}

--- a/react/components/SpecificationsTranslation/graphql/translateSpecificationValues.gql
+++ b/react/components/SpecificationsTranslation/graphql/translateSpecificationValues.gql
@@ -1,0 +1,4 @@
+mutation translateFieldValues($args: FieldValueInputTranslation, $locale: Locale) {
+  translateFieldValues(fieldValues: $args, locale: $locale)
+    @context(provider: "vtex.catalog-graphql")
+}

--- a/react/typings/catalog.d.ts
+++ b/react/typings/catalog.d.ts
@@ -60,6 +60,15 @@ interface Field extends FieldInputTranslation {
 interface FieldInputTranslation {
   name: string
 }
+interface SpecificationValuesTranslation {
+  fieldId: string
+  fieldValuesNames: SpecificationValuesUnit[]
+}
+
+interface SpecificationValuesUnit {
+  id: string
+  name: string
+}
 interface CategoriesNameAndId {
   getCategoriesName: Array<{ id: string; name: string }>
 }


### PR DESCRIPTION
**What problem is this solving?**

Add feature to translate specification values

**How should this be manually tested?**

you could  install this version in a tested workspace

vtex.admin-catalog-translation@2.3.2-beta.0