### PR TITLE
Increased TTL to 60 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Increased TTL to 60 minutes
+
 ## [2.3.2] - 2024-10-28
 
 ### Add

--- a/node/service.json
+++ b/node/service.json
@@ -1,6 +1,6 @@
 {
   "memory": 1024,
-  "ttl": 10,
+  "ttl": 60,
   "timeout": 60,
   "minReplicas": 2,
   "maxReplicas": 10,


### PR DESCRIPTION
**What problem is this solving?**
We noticed that a Tier 1 customer was having many "wake-up" events coming from this App.
To mitigate this issue, I'm increasing the TTL to 60 minutes.

<!--- What is the motivation and context for this change? -->

**Screenshots:**
![image](https://github.com/user-attachments/assets/0b9c7904-feb9-4983-a591-b0dd5aafb9e2)
